### PR TITLE
Use conditional hero image preloads for mobile and desktop

### DIFF
--- a/about.html
+++ b/about.html
@@ -9,7 +9,8 @@
   <link rel="apple-touch-icon" href="favicon.ico">
   <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
   <link rel="stylesheet" href="style.css">
-  <link rel="preload" as="image" href="nf.webp" fetchpriority="high">
+  <link rel="preload" as="image" href="nf.webp" media="(min-width:768px)">
+  <link rel="preload" as="image" href="nf-mobile.webp" media="(max-width:767px)">
 </head>
 <body>
   <!-- HEADER -->

--- a/contact.html
+++ b/contact.html
@@ -9,7 +9,8 @@
   <link rel="apple-touch-icon" href="favicon.ico" />
   <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="style.css" />
-  <link rel="preload" as="image" href="contact-bg.webp" fetchpriority="high" />
+  <link rel="preload" as="image" href="contact-bg.webp" media="(min-width:768px)" />
+  <link rel="preload" as="image" href="contact-bg-mobile.webp" media="(max-width:767px)" />
 </head>
 
 <body>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,8 @@
   <link rel="apple-touch-icon" href="favicon.ico">
   <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
   <link rel="stylesheet" href="style.css">
-  <link rel="preload" as="image" href="home-bg.webp" fetchpriority="high">
+  <link rel="preload" as="image" href="home-bg.webp" media="(min-width:768px)">
+  <link rel="preload" as="image" href="home-bg-mobile.webp" media="(max-width:767px)">
 </head>
 <body>
   <!-- HEADER -->

--- a/services.html
+++ b/services.html
@@ -9,7 +9,8 @@
   <link rel="apple-touch-icon" href="favicon.ico">
   <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
   <link rel="stylesheet" href="style.css">
-  <link rel="preload" as="image" href="services-bg.webp" fetchpriority="high">
+  <link rel="preload" as="image" href="services-bg.webp" media="(min-width:768px)">
+  <link rel="preload" as="image" href="services-bg-mobile.webp" media="(max-width:767px)">
 </head>
 <body>
 


### PR DESCRIPTION
## Summary
- Replace single hero image preload with conditional desktop/mobile variants on all pages

## Testing
- `node - <<'NODE'` (script) -> confirms correct preload image for widths 1024 and 500


------
https://chatgpt.com/codex/tasks/task_e_68991acb2f088323b845f62b72bf571e