### PR TITLE
fix: adjust hero services background

### DIFF
--- a/style.css
+++ b/style.css
@@ -90,7 +90,7 @@ nav ul li a.active { color: #FFFFFF; font-weight: 600; }
     background-image: url('nf-480.webp');
   }
   .hero-services {
-    background-image: url('services-bg-1080.webp');
+    background-image: url('services-bg-480.webp');
   }
   .hero-contact {
     background-image: url('contact-bg-480.webp');


### PR DESCRIPTION
## Summary
- default the Services hero section to the 480 px background like other hero sections
- retain both 480 px and 1080 px images in the `image-set`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68998a8e948483238149d2418a8b7b91