### PR TITLE
Use responsive JPG hero images

### DIFF
--- a/about.html
+++ b/about.html
@@ -14,9 +14,9 @@
   <!-- Styles -->
   <link rel="stylesheet" href="style.css">
 
-  <!-- Preload the hero (falls back to natasha-bg if nf-* not present) -->
-  <link rel="preload" as="image" href="images/natasha-bg.png"
-        imagesrcset="nf-480.webp 480w, nf-1080.webp 1080w, nf-480.jpg 480w, nf-1080.jpg 1080w">
+  <!-- Preload the hero image -->
+  <link rel="preload" as="image" href="nf-1080.jpg"
+        imagesrcset="nf-480.jpg 480w, nf-1080.jpg 1080w, nf-480.webp 480w, nf-1080.webp 1080w">
 
   <!-- Page-scoped styles so we don’t touch global CSS -->
   <style>
@@ -96,7 +96,8 @@
     <!-- HERO ABOUT -->
     <div class="hero-about lefty" role="img" aria-label="About Natasha hero">
   <img
-    src="natasha-bg.png"
+    src="nf-1080.jpg"
+    srcset="nf-480.jpg 480w, nf-1080.jpg 1080w, nf-480.webp 480w, nf-1080.webp 1080w"
     alt=""
     class="hero-bg"
     loading="eager"

--- a/contact.html
+++ b/contact.html
@@ -36,7 +36,8 @@
 
   <div class="hero-contact" role="img" aria-label="Contact hero">
   <img
-    src="contact-bg.png"
+    src="contact-bg-1080.jpg"
+    srcset="contact-bg-480.jpg 480w, contact-bg-1080.jpg 1080w, contact-bg-480.webp 480w, contact-bg-1080.webp 1080w"
     alt=""
     class="hero-bg"
     loading="eager"

--- a/index.html
+++ b/index.html
@@ -41,7 +41,8 @@
   <!-- HERO -->
   <div class="hero" role="img" aria-label="Project2Pixel hero">
   <img
-    src="home-bg.png"
+    src="home-bg-1080.jpg"
+    srcset="home-bg-480.jpg 480w, home-bg-1080.jpg 1080w, home-bg-480.webp 480w, home-bg-1080.webp 1080w"
     alt=""
     class="hero-bg"
     loading="eager"

--- a/services.html
+++ b/services.html
@@ -9,7 +9,7 @@
   <link rel="apple-touch-icon" href="favicon.ico">
   <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
   <link rel="stylesheet" href="style.css">
-  <link rel="preload" as="image" href="services-bg-1080.jpg" imagesrcset="services-bg-480.jpg 1x, services-bg-1080.jpg 2x, services-bg-480.webp 1x, services-bg-1080.webp 2x" fetchpriority="high">
+  <link rel="preload" as="image" href="services-bg-1080.jpg" imagesrcset="services-bg-480.jpg 480w, services-bg-1080.jpg 1080w, services-bg-480.webp 480w, services-bg-1080.webp 1080w" fetchpriority="high">
 </head>
 <body>
 
@@ -42,7 +42,8 @@
     <!-- HERO -->
     <div class="hero-services" role="img" aria-label="Services hero">
   <img
-    src="services-bg.png"
+    src="services-bg-1080.jpg"
+    srcset="services-bg-480.jpg 480w, services-bg-1080.jpg 1080w, services-bg-480.webp 480w, services-bg-1080.webp 1080w"
     alt=""
     class="hero-bg"
     loading="eager"


### PR DESCRIPTION
## Summary
- serve home, about, services and contact hero images from optimized JPG files
- add responsive srcset attributes and update preloaded resources

## Testing
- `curl -I http://localhost:8000/home-bg-1080.jpg`
- `curl -I http://localhost:8000/nf-1080.jpg`
- `curl -I http://localhost:8000/services-bg-1080.jpg`
- `curl -I http://localhost:8000/contact-bg-1080.jpg`
- `npm test` *(fails: enoent)*

------
https://chatgpt.com/codex/tasks/task_e_6899d72d195c83239e9ab21e75cc44e0