### PR TITLE
Preload hero images with WebP and JPEG fallbacks

### DIFF
--- a/about.html
+++ b/about.html
@@ -15,8 +15,16 @@
   <link rel="stylesheet" href="style.css">
 
   <!-- Preload the hero image -->
-  <link rel="preload" as="image" href="nf-1080.jpg"
-        imagesrcset="nf-480.jpg 480w, nf-1080.jpg 1080w, nf-480.webp 480w, nf-1080.webp 1080w">
+  <link rel="preload" as="image"
+        href="nf-1080.webp"
+        imagesrcset="nf-480.webp 480w, nf-1080.webp 1080w"
+        imagesizes="100vw"
+        type="image/webp">
+  <link rel="preload" as="image"
+        href="nf-1080.jpg"
+        imagesrcset="nf-480.jpg 480w, nf-1080.jpg 1080w"
+        imagesizes="100vw"
+        type="image/jpeg">
 
   <!-- Page-scoped styles so we don’t touch global CSS -->
   <style>

--- a/contact.html
+++ b/contact.html
@@ -9,7 +9,18 @@
   <link rel="apple-touch-icon" href="favicon.ico" />
   <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="style.css" />
-  <link rel="preload" as="image" href="contact-bg-1080.jpg" imagesrcset="contact-bg-480.jpg 1x, contact-bg-1080.jpg 2x, contact-bg-480.webp 1x, contact-bg-1080.webp 2x" fetchpriority="high">
+  <link rel="preload" as="image"
+        href="contact-bg-1080.webp"
+        imagesrcset="contact-bg-480.webp 1x, contact-bg-1080.webp 2x"
+        imagesizes="100vw"
+        type="image/webp"
+        fetchpriority="high">
+  <link rel="preload" as="image"
+        href="contact-bg-1080.jpg"
+        imagesrcset="contact-bg-480.jpg 1x, contact-bg-1080.jpg 2x"
+        imagesizes="100vw"
+        type="image/jpeg"
+        fetchpriority="high">
 </head>
 
 <body>

--- a/index.html
+++ b/index.html
@@ -10,8 +10,16 @@
 
     <!-- Preload hero images -->
     <link rel="preload" as="image"
+          href="home-bg-1080.webp"
+          imagesrcset="home-bg-480.webp 480w, home-bg-1080.webp 1080w"
+          imagesizes="100vw"
+          type="image/webp"
+          fetchpriority="high">
+    <link rel="preload" as="image"
           href="home-bg-1080.jpg"
-          imagesrcset="home-bg-480.jpg 480w, home-bg-1080.jpg 1080w, home-bg-480.webp 480w, home-bg-1080.webp 1080w"
+          imagesrcset="home-bg-480.jpg 480w, home-bg-1080.jpg 1080w"
+          imagesizes="100vw"
+          type="image/jpeg"
           fetchpriority="high">
 </head>
 

--- a/services.html
+++ b/services.html
@@ -9,7 +9,18 @@
   <link rel="apple-touch-icon" href="favicon.ico">
   <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
   <link rel="stylesheet" href="style.css">
-  <link rel="preload" as="image" href="services-bg-1080.jpg" imagesrcset="services-bg-480.jpg 480w, services-bg-1080.jpg 1080w, services-bg-480.webp 480w, services-bg-1080.webp 1080w" fetchpriority="high">
+    <link rel="preload" as="image"
+          href="services-bg-1080.webp"
+          imagesrcset="services-bg-480.webp 480w, services-bg-1080.webp 1080w"
+          imagesizes="100vw"
+          type="image/webp"
+          fetchpriority="high">
+    <link rel="preload" as="image"
+          href="services-bg-1080.jpg"
+          imagesrcset="services-bg-480.jpg 480w, services-bg-1080.jpg 1080w"
+          imagesizes="100vw"
+          type="image/jpeg"
+          fetchpriority="high">
 </head>
 <body>
 


### PR DESCRIPTION
## Summary
- preload hero images with WebP sources and JPEG fallbacks
- specify `imagesizes="100vw"` for responsive loading across pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899d973bf4883239ba609969f58ea6f