### PR TITLE
fix: sync contact hero preload srcset

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -9,7 +9,7 @@
   <link rel="apple-touch-icon" href="favicon.ico" />
   <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="style.css" />
-  <link rel="preload" as="image" href="contact-bg-1080.jpg" imagesrcset="contact-bg-480.jpg 1x, contact-bg-1080.jpg 2x, contact-bg-480.webp 1x, contact-bg-1080.webp 2x" fetchpriority="high">
+  <link rel="preload" as="image" href="contact-bg-1080.jpg" imagesrcset="contact-bg-480.jpg 480w, contact-bg-1080.jpg 1080w, contact-bg-480.webp 480w, contact-bg-1080.webp 1080w" imagesizes="100vw" fetchpriority="high">
 </head>
 
 <body>


### PR DESCRIPTION
## Summary
- use width descriptors for contact hero preload `imagesrcset` and add `imagesizes="100vw"`
- align preload descriptors with hero `<img>` srcset

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899d9788de48323851d5afafa5c0ad9