### PR TITLE
Use webp logo in about and services pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -22,7 +22,7 @@
   <header>
     <div class="logo-container">
       <a href="index.html">
-        <img src="images/project2pixel-logo.svg" alt="Project2Pixel Logo" class="logo" width="400" height="100">
+        <img src="project2pixel-logo.webp" alt="Project2Pixel Logo" class="logo" width="150" height="50" fetchpriority="low" decoding="async">
       </a>
       <span class="logo-text">Project<span class="highlight-2">2</span>Pixel</span>
     </div>

--- a/services.html
+++ b/services.html
@@ -22,7 +22,7 @@
   <header>
     <div class="logo-container">
       <a href="index.html">
-        <img src="images/project2pixel-logo.svg" alt="Project2Pixel Logo" class="logo" width="400" height="100">
+        <img src="project2pixel-logo.webp" alt="Project2Pixel Logo" class="logo" width="150" height="50" fetchpriority="low" decoding="async">
       </a>
       <span class="logo-text">Project<span class="highlight-2">2</span>Pixel</span>
     </div>


### PR DESCRIPTION
## Summary
- Swap header logo to existing `project2pixel-logo.webp` for about and services pages
- Match logo dimensions with other pages for consistency

## Testing
- `npm test` (fails: ENOENT: no such file or directory, open 'package.json')

------
https://chatgpt.com/codex/tasks/task_e_689a34ec69508323954aab123ab163c0