### PR TITLE
refactor: consolidate hero image preloads

### DIFF
--- a/about.html
+++ b/about.html
@@ -10,11 +10,19 @@
   <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
   <link rel="stylesheet" href="style.css">
 
-  <!-- Preload hero sources (root files) -->
-  <link rel="preload" as="image" href="nf-480.webp" type="image/webp" fetchpriority="high">
-  <link rel="preload" as="image" href="nf-1080.webp" type="image/webp" fetchpriority="high">
-  <link rel="preload" as="image" href="nf-480.jpg"  type="image/jpeg" fetchpriority="high">
-  <link rel="preload" as="image" href="nf-1080.jpg" type="image/jpeg" fetchpriority="high">
+  <!-- Preload hero image -->
+  <link rel="preload" as="image"
+        href="nf-1080.webp"
+        imagesrcset="nf-480.webp 480w, nf-1080.webp 1080w"
+        imagesizes="100vw"
+        type="image/webp"
+        fetchpriority="high">
+  <link rel="preload" as="image"
+        href="nf-1080.jpg"
+        imagesrcset="nf-480.jpg 480w, nf-1080.jpg 1080w"
+        imagesizes="100vw"
+        type="image/jpeg"
+        fetchpriority="high">
 </head>
 <body>
 

--- a/contact.html
+++ b/contact.html
@@ -10,11 +10,19 @@
   <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="style.css" />
 
-  <!-- Preload hero sources (root files) -->
-  <link rel="preload" as="image" href="contact-bg-480.webp" type="image/webp" fetchpriority="high">
-  <link rel="preload" as="image" href="contact-bg-1080.webp" type="image/webp" fetchpriority="high">
-  <link rel="preload" as="image" href="contact-bg-480.jpg"  type="image/jpeg" fetchpriority="high">
-  <link rel="preload" as="image" href="contact-bg-1080.jpg" type="image/jpeg" fetchpriority="high">
+  <!-- Preload hero image -->
+  <link rel="preload" as="image"
+        href="contact-bg-1080.webp"
+        imagesrcset="contact-bg-480.webp 480w, contact-bg-1080.webp 1080w"
+        imagesizes="100vw"
+        type="image/webp"
+        fetchpriority="high">
+  <link rel="preload" as="image"
+        href="contact-bg-1080.jpg"
+        imagesrcset="contact-bg-480.jpg 480w, contact-bg-1080.jpg 1080w"
+        imagesizes="100vw"
+        type="image/jpeg"
+        fetchpriority="high">
 </head>
 
 <body>

--- a/index.html
+++ b/index.html
@@ -8,11 +8,19 @@
     <link rel="stylesheet" href="style.css"/>
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@600;700&family=Poppins:wght@300;400;500&display=swap" rel="stylesheet">
 
-    <!-- Preload hero sources (root files) -->
-    <link rel="preload" as="image" href="home-bg-480.webp" type="image/webp" fetchpriority="high">
-    <link rel="preload" as="image" href="home-bg-1080.webp" type="image/webp" fetchpriority="high">
-    <link rel="preload" as="image" href="home-bg-480.jpg"  type="image/jpeg" fetchpriority="high">
-    <link rel="preload" as="image" href="home-bg-1080.jpg" type="image/jpeg" fetchpriority="high">
+    <!-- Preload hero image -->
+    <link rel="preload" as="image"
+          href="home-bg-1080.webp"
+          imagesrcset="home-bg-480.webp 480w, home-bg-1080.webp 1080w"
+          imagesizes="100vw"
+          type="image/webp"
+          fetchpriority="high">
+    <link rel="preload" as="image"
+          href="home-bg-1080.jpg"
+          imagesrcset="home-bg-480.jpg 480w, home-bg-1080.jpg 1080w"
+          imagesizes="100vw"
+          type="image/jpeg"
+          fetchpriority="high">
 </head>
 
 <body>

--- a/services.html
+++ b/services.html
@@ -10,11 +10,19 @@
   <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
   <link rel="stylesheet" href="style.css">
 
-  <!-- Preload hero sources (root files) -->
-  <link rel="preload" as="image" href="home-bg-480.webp" type="image/webp" fetchpriority="high">
-  <link rel="preload" as="image" href="home-bg-1080.webp" type="image/webp" fetchpriority="high">
-  <link rel="preload" as="image" href="home-bg-480.jpg"  type="image/jpeg" fetchpriority="high">
-  <link rel="preload" as="image" href="home-bg-1080.jpg" type="image/jpeg" fetchpriority="high">
+  <!-- Preload hero image -->
+  <link rel="preload" as="image"
+        href="services-bg-1080.webp"
+        imagesrcset="services-bg-480.webp 480w, services-bg-1080.webp 1080w"
+        imagesizes="100vw"
+        type="image/webp"
+        fetchpriority="high">
+  <link rel="preload" as="image"
+        href="services-bg-1080.jpg"
+        imagesrcset="services-bg-480.jpg 480w, services-bg-1080.jpg 1080w"
+        imagesizes="100vw"
+        type="image/jpeg"
+        fetchpriority="high">
 </head>
 <body>
 


### PR DESCRIPTION
## Summary
- consolidate `<link rel="preload">` entries into responsive `imagesrcset` declarations for hero images
- correct Services page to preload its own hero background

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a3919b3c483238e662caf3b0adbc8