### PR TITLE
Make feature cards stack on small screens

### DIFF
--- a/style.css
+++ b/style.css
@@ -177,6 +177,15 @@ h1, h2, h3, h4, h5, h6 { color: var(--teal); font-family: 'Montserrat', sans-ser
   text-align: center;
 }
 
+/* Stack cards on narrow screens */
+@media (max-width: 600px) {
+  .feature-card,
+  .service-card {
+    width: 100%;
+    max-width: 100%;
+  }
+}
+
 /* ========================
    ALL PACKAGES SHOW/HIDE
 ======================== */


### PR DESCRIPTION
## Summary
- Ensure feature and service cards expand to full width on small screens to prevent horizontal overflow

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689a400f2db8832394c806335512be60