### PR TITLE
Use tiny WebP placeholders for hero images

### DIFF
--- a/about.html
+++ b/about.html
@@ -53,7 +53,7 @@
     <picture>
       <source type="image/webp" srcset="nf-480.webp 480w, nf-1080.webp 1080w" sizes="100vw">
       <img
-        src="nf-1080.jpg"
+        src="data:image/webp;base64,UklGRiIAAABXRUJQVlA4ICQAAAAwAQCdASoIAAgAAkA4JaQAA3AA/vuUAAA="
         srcset="nf-480.jpg 480w, nf-1080.jpg 1080w"
         sizes="100vw"
         class="hero-bg blur-up"

--- a/contact.html
+++ b/contact.html
@@ -51,7 +51,7 @@
   <picture>
     <source type="image/webp" srcset="contact-bg-480.webp 480w, contact-bg-1080.webp 1080w" sizes="100vw">
     <img
-      src="contact-bg-1080.jpg"
+      src="data:image/webp;base64,UklGRiIAAABXRUJQVlA4ICQAAAAwAQCdASoIAAgAAkA4JaQAA3AA/vuUAAA="
       srcset="contact-bg-480.jpg 480w, contact-bg-1080.jpg 1080w"
       sizes="100vw"
       class="hero-bg blur-up"

--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
   <picture>
     <source type="image/webp" srcset="home-bg-480.webp 480w, home-bg-1080.webp 1080w" sizes="100vw">
     <img
-      src="home-bg-1080.jpg"
+      src="data:image/webp;base64,UklGRiIAAABXRUJQVlA4ICQAAAAwAQCdASoIAAgAAkA4JaQAA3AA/vuUAAA="
       srcset="home-bg-480.jpg 480w, home-bg-1080.jpg 1080w"
       sizes="100vw"
       class="hero-bg blur-up"

--- a/services.html
+++ b/services.html
@@ -54,7 +54,7 @@
     <picture>
       <source type="image/webp" srcset="services-bg-480.webp 480w, services-bg-1080.webp 1080w" sizes="100vw">
       <img
-        src="services-bg-1080.jpg"
+        src="data:image/webp;base64,UklGRiIAAABXRUJQVlA4ICQAAAAwAQCdASoIAAgAAkA4JaQAA3AA/vuUAAA="
         srcset="services-bg-480.jpg 480w, services-bg-1080.jpg 1080w"
         sizes="100vw"
         class="hero-bg blur-up"


### PR DESCRIPTION
## Summary
- embed a small WebP data URI as the `src` for each hero image
- retain existing `srcset` so high-resolution images replace placeholders when loaded
- preserve `onload` handler to drop the `blur-up` class once the full image loads

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ad9d4f72c8323a96735f8821efe3c