### PR TITLE
Add explicit hero image dimensions

### DIFF
--- a/about.html
+++ b/about.html
@@ -60,6 +60,8 @@
         loading="eager"
         fetchpriority="high"
         onload="this.classList.remove('blur-up')"
+        width="1080"
+        height="720"
         alt="">
     </picture>
 

--- a/contact.html
+++ b/contact.html
@@ -58,6 +58,8 @@
       loading="eager"
       fetchpriority="high"
       onload="this.classList.remove('blur-up')"
+      width="1080"
+      height="720"
       style="position:absolute; inset:0; width:100%; height:100%; object-fit:cover; z-index:0;"
       alt="">
   </picture>

--- a/index.html
+++ b/index.html
@@ -61,7 +61,9 @@
       loading="eager"
       fetchpriority="high"
       onload="this.classList.remove('blur-up')"
-      style="position:absolute; inset:0; width:100%; height:100%; object-fit:cover; z-index:0;"
+      width="1080"
+      height="719"
+      style="position:absolute; inset:0; width:100%; height:100%; object-fit:cover; z-index:0; aspect-ratio:1080/719;"
       alt="">
   </picture>
 

--- a/services.html
+++ b/services.html
@@ -60,6 +60,8 @@
         class="hero-bg blur-up"
         loading="eager"
         fetchpriority="high"
+        width="1080"
+        height="720"
         alt="" onload="this.classList.remove('blur-up')">
     </picture>
 


### PR DESCRIPTION
## Summary
- Add width and height attributes to all hero images.
- Ensure non-standard home hero image uses an explicit aspect-ratio style to reserve layout space.

## Testing
- `python - <<'PY' ...` (checked hero image dimensions)

------
https://chatgpt.com/codex/tasks/task_e_689ad9dedad88323be21af2f2fcd2e12