### PR TITLE
Add script for generating blur image placeholders

### DIFF
--- a/about.html
+++ b/about.html
@@ -49,11 +49,11 @@
   </header>
 
   <!-- HERO ABOUT (single hero, left-aligned like you wanted) -->
-  <div class="hero-about lefty" role="img" aria-label="About Natasha hero" style="position:relative; overflow:hidden; background:#0b0b0b url('nf-480.jpg') center/cover no-repeat;">
+  <div class="hero-about lefty" role="img" aria-label="About Natasha hero" style="position:relative; overflow:hidden; background:#0b0b0b url('nf-blur-40w.jpg') center/cover no-repeat;">
     <picture>
       <source type="image/webp" srcset="nf-480.webp 480w, nf-1080.webp 1080w" sizes="100vw">
       <img
-        src="data:image/webp;base64,UklGRiIAAABXRUJQVlA4ICQAAAAwAQCdASoIAAgAAkA4JaQAA3AA/vuUAAA="
+        src="nf-blur-40w.jpg"
         srcset="nf-480.jpg 480w, nf-1080.jpg 1080w"
         sizes="100vw"
         class="hero-bg blur-up"

--- a/contact.html
+++ b/contact.html
@@ -47,11 +47,11 @@
     </nav>
   </header>
 
-  <div class="hero-contact">
+  <div class="hero-contact" style="background:#0b0b0b url('contact-bg-blur-40w.jpg') center/cover no-repeat;">
   <picture>
     <source type="image/webp" srcset="contact-bg-480.webp 480w, contact-bg-1080.webp 1080w" sizes="100vw">
     <img
-      src="data:image/webp;base64,UklGRiIAAABXRUJQVlA4ICQAAAAwAQCdASoIAAgAAkA4JaQAA3AA/vuUAAA="
+      src="contact-bg-blur-40w.jpg"
       srcset="contact-bg-480.jpg 480w, contact-bg-1080.jpg 1080w"
       sizes="100vw"
       class="hero-bg blur-up"

--- a/index.html
+++ b/index.html
@@ -50,11 +50,11 @@
   </header>
 
   <!-- HERO -->
-  <div class="hero">
+  <div class="hero" style="background:#0b0b0b url('home-bg-blur-40w.jpg') center/cover no-repeat;">
   <picture>
     <source type="image/webp" srcset="home-bg-480.webp 480w, home-bg-1080.webp 1080w" sizes="100vw">
     <img
-      src="data:image/webp;base64,UklGRiIAAABXRUJQVlA4ICQAAAAwAQCdASoIAAgAAkA4JaQAA3AA/vuUAAA="
+      src="home-bg-blur-40w.jpg"
       srcset="home-bg-480.jpg 480w, home-bg-1080.jpg 1080w"
       sizes="100vw"
       class="hero-bg blur-up"

--- a/scripts/generate-blurs.mjs
+++ b/scripts/generate-blurs.mjs
@@ -1,0 +1,22 @@
+import fs from "fs";
+import path from "path";
+import sharp from "sharp";
+
+// Generate 40px-wide blurred placeholders for all images in the project root.
+// The resulting files can be used as low-res previews while the full hero
+// images load.
+const inDir = ".";
+const outDir = ".";
+
+for (const f of fs.readdirSync(inDir)) {
+  if (!/\.(jpe?g|png|webp)$/i.test(f)) continue;
+  if (/-blur-40w\.jpg$/i.test(f)) continue;
+  const name = path.parse(f).name;
+  const outPath = path.join(outDir, `${name}-blur-40w.jpg`);
+  await sharp(path.join(inDir, f))
+    .resize({ width: 40 })
+    .jpeg({ quality: 38, progressive: true })
+    .blur(8)
+    .toFile(outPath);
+  console.log(`Made ${path.basename(outPath)}`);
+}

--- a/services.html
+++ b/services.html
@@ -50,11 +50,11 @@
 
   <!-- HERO (same pattern as Contact, with responsive picture) -->
   <div class="hero-services" role="img" aria-label="Services hero"
-       style="position:relative; overflow:hidden; background:#0b0b0b url('services-bg-480.jpg') center/cover no-repeat;">
+       style="position:relative; overflow:hidden; background:#0b0b0b url('services-bg-blur-40w.jpg') center/cover no-repeat;">
     <picture>
       <source type="image/webp" srcset="services-bg-480.webp 480w, services-bg-1080.webp 1080w" sizes="100vw">
       <img
-        src="data:image/webp;base64,UklGRiIAAABXRUJQVlA4ICQAAAAwAQCdASoIAAgAAkA4JaQAA3AA/vuUAAA="
+        src="services-bg-blur-40w.jpg"
         srcset="services-bg-480.jpg 480w, services-bg-1080.jpg 1080w"
         sizes="100vw"
         class="hero-bg blur-up"


### PR DESCRIPTION
## Summary
- generate 40px-wide blurred image placeholders in the project root
- load those blurred placeholders first so hero images display a preview while full-resolution images load

## Testing
- `node scripts/generate-blurs.mjs` *(fails: Cannot find package 'sharp')*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ae9706d988323b73a9cdc481a1c8e