### PR TITLE
Update About hero image to use founderimage.jpeg

### DIFF
--- a/style.css
+++ b/style.css
@@ -203,11 +203,7 @@ nav { position: relative; }
   min-height: 420px;
   overflow: hidden;
   background-color: #0b0b0b;
-  background-image: url('/nf-1080.jpg');
-  background-image: image-set(
-    url('/nf-480.webp') 1x,
-    url('/nf-1080.webp') 2x
-  );
+  background-image: url('/founderimage.jpeg');
   background-position: 68% 14%;
   background-size: cover;
   background-repeat: no-repeat;


### PR DESCRIPTION
### Motivation
- Swap the About page hero asset to the new founder portrait so the founder image is shown in the hero area.

### Description
- Change the `.hero-about` `background-image` in `style.css` to `url('/founderimage.jpeg')` and remove the previous `image-set` entries while preserving layout rules like `min-height`, `background-size: cover`, and `background-position` so the visual size remains unchanged.

### Testing
- No automated tests were run for this CSS-only asset update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f88ba427a08323a8660696ce4a4f2e)