### PR TITLE
Adjust about hero image framing to keep founder face visible

### DIFF
--- a/style.css
+++ b/style.css
@@ -204,7 +204,7 @@ nav { position: relative; }
   overflow: hidden;
   background-color: #0b0b0b;
   background-image: url('/founderimage.jpeg');
-  background-position: 68% 14%;
+  background-position: 64% 10%;
   background-size: cover;
   background-repeat: no-repeat;
 }
@@ -350,7 +350,7 @@ footer p { font-size: 0.92rem; color: var(--muted); }
   .hero-about {
     min-height: 620px;
     padding: 132px 6% 92px;
-    background-position: 68% 16%;
+    background-position: 64% 12%;
   }
 }
 
@@ -360,7 +360,7 @@ footer p { font-size: 0.92rem; color: var(--muted); }
     min-height: calc(100vh - var(--header-h));
     padding: 88px 6% 80px;
     background-size: 125%;
-    background-position: 72% 68%;
+    background-position: 68% 22%;
   }
 }
 
@@ -394,7 +394,7 @@ footer p { font-size: 0.92rem; color: var(--muted); }
   }
 
   .hero-about {
-    background-position: 72% 18%;
+    background-position: 66% 12%;
   }
 
   .hero p {


### PR DESCRIPTION
### Motivation
- Ensure the founder portrait is framed so the face and shoulders remain visible across typical viewport sizes on the About page. 
- Tune the hero background crop rather than replacing the image so the existing visual and overlay effects are preserved.

### Description
- Updated `style.css` `.hero-about` base `background-position` from `68% 14%` to `64% 10%` to raise and slightly re-center the portrait. 
- Adjusted the laptop breakpoint (`@media (min-width: 992px) and (max-width: 1399px)`) `background-position` to `64% 12%` to keep face and shoulders visible. 
- Adjusted the wide-laptop breakpoint (`@media (min-width: 1400px) and (max-width: 1900px)`) `background-position` to `68% 22%` for a tighter full-bleed portrait. 
- Adjusted the mobile breakpoint (`@media (max-width: 768px)`) `background-position` to `66% 12%` to prevent the face from being cropped off on small screens.

### Testing
- Ran `rg` to locate all `.hero-about` and related `background-position` occurrences and confirmed all variants were updated successfully. 
- Verified the CSS changes with `git diff -- style.css` and inspected the resulting file with `nl -ba style.css`, both of which succeeded. 
- Committed the change (commit completed successfully) and generated the PR metadata with the repository tooling, which succeeded. 
- Attempted automated face-detection using `python` with `cv2` and `PIL` during verification, but those attempts failed due to missing modules (`ModuleNotFoundError`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f88da541f08323bd998015e75c71a0)