### PR TITLE
Adjust About hero image framing to keep founder's face visible

### DIFF
--- a/style.css
+++ b/style.css
@@ -199,12 +199,12 @@ nav { position: relative; }
   align-items: center;
   justify-content: flex-start;
   text-align: left;
-  padding: 120px 6%;
-  min-height: 420px;
+  padding: 100px 6%;
+  min-height: 460px;
   overflow: hidden;
   background-color: #0b0b0b;
   background-image: url('/founderimage.jpeg');
-  background-position: 64% 10%;
+  background-position: center 14%;
   background-size: cover;
   background-repeat: no-repeat;
 }
@@ -350,7 +350,7 @@ footer p { font-size: 0.92rem; color: var(--muted); }
   .hero-about {
     min-height: 620px;
     padding: 132px 6% 92px;
-    background-position: 64% 12%;
+    background-position: 62% 12%;
   }
 }
 
@@ -359,8 +359,8 @@ footer p { font-size: 0.92rem; color: var(--muted); }
   .hero-about {
     min-height: calc(100vh - var(--header-h));
     padding: 88px 6% 80px;
-    background-size: 125%;
-    background-position: 68% 22%;
+    background-size: 115%;
+    background-position: 64% 20%;
   }
 }
 
@@ -394,7 +394,9 @@ footer p { font-size: 0.92rem; color: var(--muted); }
   }
 
   .hero-about {
-    background-position: 66% 12%;
+    min-height: 420px;
+    background-size: 132%;
+    background-position: 56% 10%;
   }
 
   .hero p {


### PR DESCRIPTION
### Motivation
- Make the About page hero visual match other pages’ full-width hero treatment and ensure the founder image is framed so the face remains visible on both mobile and desktop breakpoints.

### Description
- Updated `.hero-about` in `style.css` to change `padding`, `min-height`, `background-position`, and `background-size` for a consistent full-bleed presentation and tighter framing around the portrait.
- Tuned breakpoint-specific rules for `@media (min-width: 992px) and (max-width: 1399px)`, `@media (min-width: 1400px) and (max-width: 1900px)`, and `@media (max-width: 768px)` to adjust background positioning and scaling so the face and shoulders remain visible across laptop, wide-screen, and mobile.

### Testing
- Located and reviewed hero rules with `rg` and inspected the updated `style.css` with `sed`/`nl` to confirm the new properties are present and correctly applied.
- Ran the automated replacement script used to apply the edits and verified the resulting diff to ensure only intended CSS changes were made.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f89e1c0b2483238fe362ed0d04f54f)