### PR TITLE
Fix footer privacy link and apply brand color to footer links

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -109,7 +109,7 @@ Project<span class="brand-2">2</span>Pixel is being built to serve both commerci
 <footer>
     <p>&copy; 2025 Project<span class="brand-2">2</span>Pixel </p>
     <p>
-        <a href="privacy.html">Privacy Policy</a> |
+        <a href="/privacy.html">Privacy Policy</a> |
         <a href="terms.html">Terms of Service</a> |
         <a href="cancellation.html">Cancellation Policy</a>
     </p>

--- a/contact/index.html
+++ b/contact/index.html
@@ -105,7 +105,7 @@ That’s exactly where we come in. We take what feels messy and turn it into str
 <footer>
     <p>&copy; 2025 Project<span class="brand-2">2</span>Pixel </p>
     <p>
-        <a href="privacy.html">Privacy Policy</a> |
+        <a href="/privacy.html">Privacy Policy</a> |
         <a href="terms.html">Terms of Service</a> |
         <a href="cancellation.html">Cancellation Policy</a>
     </p>

--- a/index.html
+++ b/index.html
@@ -154,7 +154,7 @@
 <footer>
     <p>&copy; 2025 Project<span class="brand-2">2</span>Pixel </p>
     <p>
-        <a href="privacy.html">Privacy Policy</a> |
+        <a href="/privacy.html">Privacy Policy</a> |
         <a href="terms.html">Terms of Service</a> |
         <a href="cancellation.html">Cancellation Policy</a>
     </p>

--- a/initiative/index.html
+++ b/initiative/index.html
@@ -147,7 +147,7 @@ The Project<span class="brand-2">2</span>Pixel AI Initiative is part of a larger
 <footer>
     <p>&copy; 2025 Project<span class="brand-2">2</span>Pixel </p>
     <p>
-        <a href="privacy.html">Privacy Policy</a> |
+        <a href="/privacy.html">Privacy Policy</a> |
         <a href="terms.html">Terms of Service</a> |
         <a href="cancellation.html">Cancellation Policy</a>
     </p>

--- a/partnerships/index.html
+++ b/partnerships/index.html
@@ -171,7 +171,7 @@ If your organisation wants to support AI readiness, digital inclusion, small bus
 <footer>
     <p>&copy; 2025 Project<span class="brand-2">2</span>Pixel </p>
     <p>
-        <a href="privacy.html">Privacy Policy</a> |
+        <a href="/privacy.html">Privacy Policy</a> |
         <a href="terms.html">Terms of Service</a> |
         <a href="cancellation.html">Cancellation Policy</a>
     </p>

--- a/services/index.html
+++ b/services/index.html
@@ -217,7 +217,7 @@ Let’s identify the systems your business or NGO needs now, and the digital inf
 <footer>
     <p>&copy; 2025 Project<span class="brand-2">2</span>Pixel </p>
     <p>
-        <a href="privacy.html">Privacy Policy</a> |
+        <a href="/privacy.html">Privacy Policy</a> |
         <a href="terms.html">Terms of Service</a> |
         <a href="cancellation.html">Cancellation Policy</a>
     </p>

--- a/speaking/index.html
+++ b/speaking/index.html
@@ -146,7 +146,7 @@ Natasha speaks at the intersection of AI transformation, governance alignment an
 <footer>
     <p>&copy; 2025 Project<span class="brand-2">2</span>Pixel </p>
     <p>
-        <a href="privacy.html">Privacy Policy</a> |
+        <a href="/privacy.html">Privacy Policy</a> |
         <a href="terms.html">Terms of Service</a> |
         <a href="cancellation.html">Cancellation Policy</a>
     </p>

--- a/style.css
+++ b/style.css
@@ -343,6 +343,8 @@ footer {
 }
 
 footer p { font-size: 0.92rem; color: var(--muted); }
+footer a { color: var(--brand); text-decoration: none; }
+footer a:hover { color: var(--brand-dark); text-decoration: underline; }
 
 
 /* Laptop framing: keep face + shoulders visible */


### PR DESCRIPTION
### Motivation
- Ensure the Privacy Policy footer link resolves correctly from pages in subdirectories by using an absolute path so users do not hit a broken relative link. 
- Make the footer links visually consistent with the site brand by matching the link color to the highlighted "2" used across the site.

### Description
- Replaced relative `href="privacy.html"` with absolute `href="/privacy.html"` in `index.html`, `about/index.html`, `contact/index.html`, `services/index.html`, `speaking/index.html`, `initiative/index.html`, and `partnerships/index.html`.
- Added footer link styling to `style.css` with `footer a { color: var(--brand); text-decoration: none; }` and `footer a:hover { color: var(--brand-dark); text-decoration: underline; }` so footer links use the brand color and a darker hover state.
- Changes update 8 files in total (7 HTML pages + `style.css`).

### Testing
- Ran a repository search with `rg -n "href=\"privacy.html\"|href=\"/privacy.html\"|footer a \{|footer a:hover"` to verify updated paths and the new CSS rules; the search returned the updated absolute links and the `style.css` rules as expected (success).
- Verified working tree with `git status --short` and committed the changes with `git commit` to record the update (commit succeeded).
- Inspected file snippets with `nl` to confirm the footer links now point to `/privacy.html` and that `style.css` contains the new footer link rules (inspection succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8acfff2008323ab449dbadef99532)