### PR TITLE
Brand-consistent link colour and fix Speaking footer policy URLs

### DIFF
--- a/speaking/index.html
+++ b/speaking/index.html
@@ -148,8 +148,8 @@ Natasha speaks at the intersection of AI transformation, governance alignment an
     <p><a href="/capability-statement.pdf">Capability Statement</a></p>
     <p>
         <a href="/privacy.html">Privacy Policy</a> |
-        <a href="terms.html">Terms of Service</a> |
-        <a href="cancellation.html">Cancellation Policy</a>
+        <a href="/terms.html">Terms of Service</a> |
+        <a href="/cancellation.html">Cancellation Policy</a>
     </p>
 </footer>
 

--- a/style.css
+++ b/style.css
@@ -325,6 +325,19 @@ input, textarea {
 input:focus, textarea:focus { outline: none; border-color: var(--brand); }
 textarea { min-height: 140px; }
 
+
+/* Global inline link styling for consistent brand color */
+a {
+  color: var(--brand);
+  text-decoration: none;
+  transition: color 0.25s ease;
+}
+
+a:hover {
+  color: var(--brand-dark);
+  text-decoration: underline;
+}
+
 a[href^="mailto"] {
   color: var(--brand);
   font-weight: 600;


### PR DESCRIPTION
### Motivation
- Ensure inline links (including Terms of Service) render in the Project2Pixel brand colour across the site and fix footer policy links that could break from nested routes.

### Description
- Add global anchor styles in `style.css` to use `var(--brand)` and `var(--brand-dark)` for hover states, and update `speaking/index.html` footer links to root-relative paths (`/terms.html`, `/cancellation.html`).

### Testing
- Ran `rg` checks to verify the inserted CSS comment and that no `href="terms.html"`/`href="cancellation.html"` remain, inspected the `git diff -- style.css speaking/index.html`, and committed the changes with `git add`/`git commit`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8c00861108323bce53791481a5f59)