### PR TITLE
Replace 'Programmes' with 'Solutions' and adjust related copy across site

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 <title>About | Project2Pixel</title>
-<meta name="description" content="Natasha Fredericks is the founder of Project2Pixel, building AI-powered workflows, automation systems and digital enablement programmes for small businesses, NGOs and underserved communities.">
+<meta name="description" content="Natasha Fredericks is the founder of Project2Pixel, building AI-powered workflows, automation systems and digital enablement solutions for small businesses, NGOs and underserved communities.">
 <link rel="stylesheet" href="/style.css">
 <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@700;800&family=Poppins:wght@300;400;500&display=swap" rel="stylesheet">
 </head>
@@ -28,7 +28,7 @@
 <li><a href="/">Home</a></li>
 <li><a href="/about/" class="active">About</a></li>
 <li><a href="/initiative/">AI Initiative</a></li>
-<li><a href="/services/">Programmes</a></li>
+<li><a href="/services/">Solutions</a></li>
 <li><a href="/speaking/">Speaking</a></li>
 <li><a href="/partnerships/">Partners</a></li>
 <li><a href="/contact/">Contact</a></li>

--- a/compliance.html
+++ b/compliance.html
@@ -28,7 +28,7 @@
 <li><a href="/">Home</a></li>
 <li><a href="/about/">About</a></li>
 <li><a href="/initiative/">AI Initiative</a></li>
-<li><a href="/services/">Programmes</a></li>
+<li><a href="/services/">Solutions</a></li>
 <li><a href="/speaking/">Speaking</a></li>
 <li><a href="/partnerships/">Partners</a></li>
 <li><a href="/contact/">Contact</a></li>

--- a/contact/index.html
+++ b/contact/index.html
@@ -28,7 +28,7 @@
 <li><a href="/">Home</a></li>
 <li><a href="/about/">About</a></li>
 <li><a href="/initiative/">AI Initiative</a></li>
-<li><a href="/services/">Programmes</a></li>
+<li><a href="/services/">Solutions</a></li>
 <li><a href="/speaking/">Speaking</a></li>
 <li><a href="/partnerships/">Partners</a></li>
 <li><a href="/contact/" class="active">Contact</a></li>
@@ -98,7 +98,7 @@ That’s exactly where we come in. We take what feels messy and turn it into str
 </p>
 
 <div style="text-align:center; margin-top:30px;">
-<a href="/services/" class="btn-consultation">View Programmes</a>
+<a href="/services/" class="btn-consultation">View Solutions</a>
 </div>
 </section>
 

--- a/initiative/index.html
+++ b/initiative/index.html
@@ -28,7 +28,7 @@
 <li><a href="/">Home</a></li>
 <li><a href="/about/">About</a></li>
 <li><a href="/initiative/" class="active">AI Initiative</a></li>
-<li><a href="/services/">Programmes</a></li>
+<li><a href="/services/">Solutions</a></li>
 <li><a href="/speaking/">Speaking</a></li>
 <li><a href="/partnerships/">Partners</a></li>
 <li><a href="/contact/">Contact</a></li>
@@ -43,7 +43,7 @@ A practical AI and digital enablement initiative helping small businesses, NGOs 
 </p>
 
 <div class="btn-row">
-<a href="/services/" class="btn-consultation">Explore Programmes</a>
+<a href="/services/" class="btn-consultation">Explore Solutions</a>
 <a href="/contact/" class="btn-consultation secondary">Partner With Us</a>
 </div>
 </div>
@@ -102,7 +102,7 @@ AI is changing how businesses operate, how organisations serve communities and h
 
 <div class="feature-card">
 <h3>Institutions & Partners</h3>
-<p>Organisations looking to support responsible AI adoption, skills development and digital inclusion programmes.</p>
+<p>Organisations looking to support responsible AI adoption, skills development and digital inclusion solutions.</p>
 </div>
 </div>
 </section>

--- a/speaking/index.html
+++ b/speaking/index.html
@@ -28,7 +28,7 @@
 <li><a href="/">Home</a></li>
 <li><a href="/about/">About</a></li>
 <li><a href="/initiative/">AI Initiative</a></li>
-<li><a href="/services/">Programmes</a></li>
+<li><a href="/services/">Solutions</a></li>
 <li><a href="/speaking/" class="active">Speaking</a></li>
 <li><a href="/partnerships/">Partners</a></li>
 <li><a href="/contact/">Contact</a></li>


### PR DESCRIPTION
### Motivation
- Standardise the public-facing terminology from "Programmes" to "Solutions" across the site to improve clarity and align messaging. 

### Description
- Updated the header navigation label from "Programmes" to "Solutions" in multiple page templates (`about/index.html`, `compliance.html`, `contact/index.html`, `initiative/index.html`, `speaking/index.html`).
- Updated call-to-action copy linking to the services page (for example `View Programmes` -> `View Solutions`) in `contact/index.html` and `initiative/index.html` buttons.
- Adjusted related copy and metadata to reflect the new wording, including the `meta` description in `about/index.html` and a line in `initiative/index.html` changing "programmes" to "solutions".

### Testing
- No automated tests were executed for this content-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8d52163fc8323b6a8eaaabac64ad5)