### PR TITLE
Fix partnerships header menu to match other pages

### DIFF
--- a/partnerships/index.html
+++ b/partnerships/index.html
@@ -23,10 +23,17 @@
 </div>
 
 <nav>
-<ul>
+<div class="hamburger" id="hamburger">
+<span></span><span></span><span></span>
+</div>
+
+<ul class="nav-links" id="navLinks">
 <li><a href="/">Home</a></li>
 <li><a href="/about/">About</a></li>
+<li><a href="/initiative/">AI Initiative</a></li>
 <li><a href="/services/">Solutions</a></li>
+<li><a href="/speaking/">Speaking</a></li>
+<li><a href="/partnerships/" class="active">Partners</a></li>
 <li><a href="/contact/">Contact</a></li>
 </ul>
 </nav>
@@ -188,6 +195,8 @@ Project2Pixel (PTY) Ltd | Reg: 2025/625844/07 | Level 1 B-BBEE Contributor
 <a href="/cancellation.html">Cancellation Policy</a>
 </p>
 </footer>
+
+<script src="/script.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- The Partnerships page used an older, non-responsive header that was inconsistent with the rest of the site and lacked the hamburger/menu behavior used on other pages.
- The change aligns navigation structure so mobile toggling and active link state behave consistently across pages.

### Description
- Updated `partnerships/index.html` header to include the hamburger toggle and the `ul` with `class="nav-links"` and `id="navLinks"` matching other pages.
- Added missing nav items (`AI Initiative`, `Speaking`) and marked the Partnerships link as `class="active"` for correct page context.
- Injected the shared site script include by adding `<script src="/script.js"></script>` before `</body>` so the hamburger/menu behavior runs on the Partnerships page.

### Testing
- Verified the change with `git diff -- partnerships/index.html` and committed the file; the diff shows only the header/navigation and script include edits.
- No automated test suite is configured for this static site repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8d87201f083238bd0e1678d2d0524)