### PR TITLE
Fix contact page CTA copy and send button styling

### DIFF
--- a/contact/index.html
+++ b/contact/index.html
@@ -32,7 +32,7 @@
 </header>
 
 <div class="hero-contact">
-<h1>Contact Me</h1>
+<h1>Contact Us</h1>
 <p>Have a project in mind? Let's make it a reality.</p>
 </div>
 
@@ -69,9 +69,9 @@ Use this form for service enquiries, partnership discussions, programme ideas, f
 <input type="email" id="email" name="_replyto" required>
 
 <label for="message">Your Message:</label>
-<textarea id="message" name="message" placeholder="Tell me about your project..." required></textarea>
+<textarea id="message" name="message" placeholder="Tell us about your project..." required></textarea>
 
-<button type="submit">Send Message</button>
+<button type="submit" class="btn-consultation">Send Message</button>
 
 <p style="font-size: 0.9rem; margin-top: 10px;">
 By submitting, you agree to our <a href="/terms.html">Terms of Service</a>.


### PR DESCRIPTION
### Motivation
- Improve the contact page CTA copy for inclusive voice and ensure the form submit button uses the site's CTA styling so it is visually prominent and consistent.

### Description
- Updated the hero heading from `Contact Me` to `Contact Us` in `contact/index.html`.
- Changed the message textarea placeholder from `Tell me about your project...` to `Tell us about your project...`.
- Added the `btn-consultation` class to the form submit button so the `Send Message` button uses the site CTA styles.

### Testing
- Verified the HTML diff for `contact/index.html` and inspected the file excerpt with `nl -ba contact/index.html | sed -n '30,90p'` to confirm the heading, placeholder, and button class updates (checks succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8ece9dce083239b1c0d487b317ca3)