### PR TITLE
Center and standardize AI Initiative and Partners hero headers

### DIFF
--- a/style.css
+++ b/style.css
@@ -96,7 +96,8 @@ nav { position: relative; }
 /* Hero base */
 .hero,
 .hero-contact,
-.heroinitiative {
+.heroinitiative,
+.hero-services {
   position: relative;
   text-align: center;
   padding: 100px 20px;
@@ -106,7 +107,8 @@ nav { position: relative; }
 
 .hero h1,
 .hero-contact h1,
-.heroinitiative h1 {
+.heroinitiative h1,
+.hero-services h1 {
   font-family: "Montserrat", sans-serif;
   font-size: clamp(2rem, 4vw, 3.2rem);
   line-height: 1.08;
@@ -115,7 +117,8 @@ nav { position: relative; }
 
 .hero p,
 .hero-contact p,
-.heroinitiative p {
+.heroinitiative p,
+.hero-services p {
   max-width: 900px;
   margin: 0 auto 22px;
   color: var(--muted);
@@ -407,9 +410,14 @@ footer a:hover { color: var(--brand-dark); text-decoration: underline; }
 
   .hero,
   .hero-contact,
-  .heroinitiative,
   .hero-about {
     text-align: left;
+    padding: 72px 6% 56px;
+  }
+
+  .heroinitiative,
+  .hero-services {
+    text-align: center;
     padding: 72px 6% 56px;
   }
 


### PR DESCRIPTION
### Motivation
- Ensure the Partners and AI Initiative pages use the same hero header styling as other site hero sections for visual consistency.
- Center the top headers on those pages to match the rest of the site layout and improve alignment on small screens.
- Preserve the left-aligned hero layout for the `About` page which uses a different image/portrait layout.

### Description
- Updated `style.css` to include `.hero-services` in the shared hero base selector so it inherits the same layout rules as other heroes.
- Extended the hero heading and paragraph selectors to include `.hero-services` so fonts and max-width match (`.hero h1`, `.hero p`, etc.).
- Adjusted the mobile media query to explicitly keep `.heroinitiative` and `.hero-services` centered while leaving `.hero-about` left-aligned.

### Testing
- Ran `git diff -- style.css` to inspect the change and the diff output matched the intended selector updates and mobile tweaks, which succeeded.
- Committed the change with `git commit -m "Center and unify AI Initiative and Partners hero headers"`, and the commit completed successfully.
- Reviewed the modified file with `nl -ba style.css` to confirm the updated selectors and media query lines were present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f98dcf8d0083238eb85d1bec14b7e8)