### PR TITLE
Adjust About hero framing and unify Project2Pixel '2' brand styling

### DIFF
--- a/script.js
+++ b/script.js
@@ -27,3 +27,30 @@ if (hamburger && navLinks) {
     if (e.key === "Escape") closeMenu()
   })
 }
+
+const highlightProject2Pixel = () => {
+  const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT)
+  const textNodes = []
+
+  while (walker.nextNode()) {
+    const node = walker.currentNode
+    if (!node.nodeValue.includes("Project2Pixel")) continue
+
+    const parent = node.parentElement
+    if (!parent) continue
+    if (parent.closest("script, style, title, meta")) continue
+    if (parent.classList.contains("logo-text")) continue
+
+    textNodes.push(node)
+  }
+
+  textNodes.forEach((node) => {
+    const wrapper = document.createElement("span")
+    wrapper.innerHTML = node.nodeValue.replaceAll("Project2Pixel", 'Project<span class="brand-2">2</span>Pixel')
+    node.parentNode.replaceChild(wrapper, node)
+  })
+}
+
+if (document.body) {
+  highlightProject2Pixel()
+}

--- a/style.css
+++ b/style.css
@@ -207,7 +207,7 @@ nav { position: relative; }
   overflow: hidden;
   background-color: #0b0b0b;
   background-image: url('/founderimage.jpeg');
-  background-position: 72% 18%;
+  background-position: 62% 10%;
   background-size: cover;
   background-repeat: no-repeat;
 }
@@ -373,7 +373,7 @@ footer a:hover { color: var(--brand-dark); text-decoration: underline; }
   .hero-about {
     min-height: 0;
     padding: 100px 6%;
-    background-position: 70% 16%;
+    background-position: 60% 12%;
   }
 }
 
@@ -383,7 +383,7 @@ footer a:hover { color: var(--brand-dark); text-decoration: underline; }
     min-height: 0;
     padding: 100px 6%;
     background-size: cover;
-    background-position: 68% 18%;
+    background-position: 58% 14%;
   }
 }
 
@@ -424,7 +424,7 @@ footer a:hover { color: var(--brand-dark); text-decoration: underline; }
   .hero-about {
     min-height: 0;
     background-size: cover;
-    background-position: 64% 14%;
+    background-position: 56% 10%;
   }
 
   .hero p {


### PR DESCRIPTION
### Motivation
- Improve the visual framing of the About page hero so the founder's face and upper body are visible in the hero section, and make the digit "2" in the site name consistently use the brand color everywhere it appears in page content.

### Description
- Tuned the About hero background positioning in `style.css` to center the founder image more prominently (`.hero-about` base, laptop and wide-screen `@media` breakpoints, and mobile breakpoint adjustments). 
- Added a client-side formatter in `script.js` (`highlightProject2Pixel`) that replaces plain `Project2Pixel` text nodes with `Project<span class="brand-2">2</span>Pixel` so the `2` uses the `.brand-2` styling site-wide. 
- The formatter skips existing logo text nodes by excluding elements with the `logo-text` class and avoids altering content inside `script`, `style`, `title`, or `meta` elements.
- Only `style.css` and `script.js` were modified in this change.

### Testing
- No automated tests were executed for these static CSS/JS adjustments.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f993648a0c8323b932dd76b7cff114)