### PR TITLE
fix: correct company name typo on about page

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -110,7 +110,7 @@ Project<span class="brand-2">2</span>Pixel is being built to serve both commerci
 <h2>Registered Business</h2>
 
 <p style="max-width:900px; margin:0 auto;">
-Project<span class="highlight-2">2</span>Pixel operates through Poject2Pixel (PTY) LTD, a South African registered private company providing digital transformation, workflow systems, AI enablement and operational support services.
+Project<span class="highlight-2">2</span>Pixel operates through Project2Pixel (PTY) LTD, a South African registered private company providing digital transformation, workflow systems, AI enablement and operational support services.
 </p>
 </section>
 


### PR DESCRIPTION
### Motivation
- Fix a visible typo in the About page's Registered Business section where the company name was misspelled as `Poject2Pixel (PTY) LTD` which could confuse readers or look unprofessional.

### Description
- Updated `about/index.html` to replace `Poject2Pixel (PTY) LTD` with `Project2Pixel (PTY) LTD`.

### Testing
- Ran `rg` to locate the misspelling and confirm the replacement, and executed `node --check script.js` and `python -m py_compile` which both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9943c24188323aa46e53038e4bb09)