### PR TITLE
Adjust About hero image framing to show face and dress

### DIFF
--- a/style.css
+++ b/style.css
@@ -207,7 +207,7 @@ nav { position: relative; }
   overflow: hidden;
   background-color: #0b0b0b;
   background-image: url('/founderimage.jpeg');
-  background-position: 62% 10%;
+  background-position: 62% 22%;
   background-size: cover;
   background-repeat: no-repeat;
 }
@@ -373,7 +373,7 @@ footer a:hover { color: var(--brand-dark); text-decoration: underline; }
   .hero-about {
     min-height: 0;
     padding: 100px 6%;
-    background-position: 60% 12%;
+    background-position: 60% 24%;
   }
 }
 
@@ -383,7 +383,7 @@ footer a:hover { color: var(--brand-dark); text-decoration: underline; }
     min-height: 0;
     padding: 100px 6%;
     background-size: cover;
-    background-position: 58% 14%;
+    background-position: 58% 22%;
   }
 }
 
@@ -424,7 +424,7 @@ footer a:hover { color: var(--brand-dark); text-decoration: underline; }
   .hero-about {
     min-height: 0;
     background-size: cover;
-    background-position: 56% 10%;
+    background-position: 56% 18%;
   }
 
   .hero p {


### PR DESCRIPTION
### Motivation
- Ensure the founder's face and part of the dress are visible in the About page hero image across typical screen sizes.
- Improve image composition consistency across laptop, wide-laptop and mobile breakpoints without changing markup or assets.

### Description
- Updated `background-position` values for the `.hero-about` selector in `style.css` to reframe the hero image (default, laptop, wide-laptop and mobile breakpoints).
- No changes to HTML or JavaScript were required; this is a targeted visual framing update in CSS.

### Testing
- Ran an automated replacement script that updated `style.css` successfully and exited without error.
- Inspected the diff for `style.css` and confirmed only `.hero-about` `background-position` declarations were modified.
- Verified the repository recorded the file change successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9999f66c0832389251be9cbc2b94a)