### PR TITLE
Adjust hero-about background positioning for multiple breakpoints

### DIFF
--- a/style.css
+++ b/style.css
@@ -207,7 +207,7 @@ nav { position: relative; }
   overflow: hidden;
   background-color: #0b0b0b;
   background-image: url('/founderimage.jpeg');
-  background-position: 62% 10%;
+  background-position: 60% 42%;
   background-size: cover;
   background-repeat: no-repeat;
 }
@@ -373,7 +373,7 @@ footer a:hover { color: var(--brand-dark); text-decoration: underline; }
   .hero-about {
     min-height: 0;
     padding: 100px 6%;
-    background-position: 60% 12%;
+    background-position: 58% 44%;
   }
 }
 
@@ -383,7 +383,7 @@ footer a:hover { color: var(--brand-dark); text-decoration: underline; }
     min-height: 0;
     padding: 100px 6%;
     background-size: cover;
-    background-position: 58% 14%;
+    background-position: 56% 40%;
   }
 }
 
@@ -424,7 +424,7 @@ footer a:hover { color: var(--brand-dark); text-decoration: underline; }
   .hero-about {
     min-height: 0;
     background-size: cover;
-    background-position: 56% 10%;
+    background-position: 54% 34%;
   }
 
   .hero p {


### PR DESCRIPTION
### Motivation
- Improve framing of the hero founder image so the face and shoulders remain visible across desktop, laptop, and mobile viewports.
- Reduce awkward cropping at several responsive breakpoints by shifting the background focal point.

### Description
- Updated the base `.hero-about` `background-position` from `62% 10%` to `60% 42%`.
- Adjusted responsive `background-position` values in the 992–1399px, 1400–1900px, and `max-width: 768px` media queries to `58% 44%`, `56% 40%`, and `54% 34%` respectively.
- No HTML or JavaScript changes were made and `background-size: cover` and existing overlay rules remain unchanged.

### Testing
- Ran `stylelint` against `style.css` and it completed without errors.
- Executed the site build with `npm run build` and the build succeeded.
- No automated visual regression tests are configured for CSS in this repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9999f66c0832389251be9cbc2b94a)