### PR TITLE
Adjust hero image framing to show more of the green dress

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
   </nav>
 </header>
 
-<section class="hero" style="background:#0b0b0b url('/home-bg-1080.jpg') center/cover no-repeat;">
+<section class="hero" style="background:#0b0b0b url('/home-bg-1080.jpg') center 20%/cover no-repeat;">
   <p class="hero-lead">AI-powered workflows • automation • digital systems</p>
 
   <h1>Smart Systems for Businesses That Are Ready to Grow</h1>


### PR DESCRIPTION
### Motivation
- Ensure more of the subject's green dress is visible in the homepage hero crop by shifting the background framing.

### Description
- Updated the inline hero background shorthand in `index.html` from `center/cover` to `center 20%/cover`, preserving the same image, overlay, and sizing behavior.

### Testing
- Verified the single-line change in `index.html` and confirmed the diff contains only the updated background positioning; an attempt to capture a local screenshot with `npx playwright screenshot` failed due to npm registry access restrictions in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9a5b9cec88323b361fbed2e7ef40d)