### PR TITLE
Adjust About hero image framing to reveal more of green dress

### DIFF
--- a/style.css
+++ b/style.css
@@ -207,7 +207,7 @@ nav { position: relative; }
   overflow: hidden;
   background-color: #0b0b0b;
   background-image: url('/founderimage.jpeg');
-  background-position: 62% 22%;
+  background-position: 62% 36%;
   background-size: cover;
   background-repeat: no-repeat;
 }
@@ -373,7 +373,7 @@ footer a:hover { color: var(--brand-dark); text-decoration: underline; }
   .hero-about {
     min-height: 0;
     padding: 100px 6%;
-    background-position: 60% 24%;
+    background-position: 60% 38%;
   }
 }
 
@@ -383,7 +383,7 @@ footer a:hover { color: var(--brand-dark); text-decoration: underline; }
     min-height: 0;
     padding: 100px 6%;
     background-size: cover;
-    background-position: 58% 22%;
+    background-position: 58% 36%;
   }
 }
 
@@ -424,7 +424,7 @@ footer a:hover { color: var(--brand-dark); text-decoration: underline; }
   .hero-about {
     min-height: 0;
     background-size: cover;
-    background-position: 56% 18%;
+    background-position: 56% 30%;
   }
 
   .hero p {


### PR DESCRIPTION
### Motivation
- Ensure the About page hero portrait reveals more of the subject's green dress by shifting the vertical focal point downward across viewports.

### Description
- Updated `style.css` to change `.hero-about` `background-position` from `62% 22%` to `62% 36%` in the base rule and to adjust laptop (`60% 24%` → `60% 38%`), wide-laptop (`58% 22%` → `58% 36%`), and mobile (`56% 18%` → `56% 30%`) breakpoints.
- This is a visual-only change with no functional code modifications.

### Testing
- Ran `git diff -- style.css` and reviewed the CSS diff to confirm the four `background-position` updates were applied (succeeded).
- Attempted to capture a visual screenshot with a Playwright script which failed due to missing Python `playwright` module (failed).
- Attempted `npx playwright --version` which failed with a registry `403` preventing installation of the screenshot tooling (failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9a683a4788323b9c637847cb850f8)