### PR TITLE
Align About hero content to the right

### DIFF
--- a/style.css
+++ b/style.css
@@ -200,7 +200,7 @@ nav { position: relative; }
   position: relative;
   display: flex;
   align-items: center;
-  justify-content: flex-start;
+  justify-content: flex-end;
   text-align: left;
   padding: 100px 6%;
   min-height: 0;
@@ -217,8 +217,8 @@ nav { position: relative; }
   position: absolute;
   inset: 0;
   background:
-    radial-gradient(circle at 70% 28%, rgba(255,255,255,0.32) 0%, rgba(255,255,255,0.08) 30%, rgba(255,255,255,0) 55%),
-    linear-gradient(90deg, rgba(0,0,0,0.52) 0%, rgba(0,0,0,0.20) 54%, rgba(0,0,0,0.10) 100%);
+    radial-gradient(circle at 32% 28%, rgba(255,255,255,0.32) 0%, rgba(255,255,255,0.08) 30%, rgba(255,255,255,0) 55%),
+    linear-gradient(90deg, rgba(0,0,0,0.10) 0%, rgba(0,0,0,0.20) 46%, rgba(0,0,0,0.52) 100%);
   z-index: 1;
 }
 


### PR DESCRIPTION
### Motivation
- Move the About page hero copy/fact block to the right for improved composition over the founder image and ensure text remains readable against the background.

### Description
- Updated `style.css` to change `.hero-about` alignment from `justify-content: flex-start` to `justify-content: flex-end` and rebalanced the `.hero-about::after` radial and linear gradients to preserve contrast for right-aligned copy.

### Testing
- No automated tests were run because this is a visual CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9a9b3c580832380c10e6d90e23f06)