### PR TITLE
Align About page hero content to the left

### DIFF
--- a/style.css
+++ b/style.css
@@ -200,7 +200,7 @@ nav { position: relative; }
   position: relative;
   display: flex;
   align-items: center;
-  justify-content: flex-end;
+  justify-content: flex-start;
   text-align: left;
   padding: 100px 6%;
   min-height: 0;
@@ -218,7 +218,7 @@ nav { position: relative; }
   inset: 0;
   background:
     radial-gradient(circle at 32% 28%, rgba(255,255,255,0.32) 0%, rgba(255,255,255,0.08) 30%, rgba(255,255,255,0) 55%),
-    linear-gradient(90deg, rgba(0,0,0,0.10) 0%, rgba(0,0,0,0.20) 46%, rgba(0,0,0,0.52) 100%);
+    linear-gradient(90deg, rgba(0,0,0,0.56) 0%, rgba(0,0,0,0.30) 48%, rgba(0,0,0,0.14) 100%);
   z-index: 1;
 }
 


### PR DESCRIPTION
### Motivation
- Move the hero text block on the About page to the left side to match the requested layout change. 
- Increase contrast on the left side of the hero overlay so left-aligned text remains readable against the background image.

### Description
- Changed `.hero-about` alignment from `justify-content: flex-end` to `justify-content: flex-start` in `style.css` to position the hero content on the left. 
- Updated the `.hero-about::after` linear-gradient stop values in `style.css` to darken the left side of the overlay for better text contrast.

### Testing
- No automated tests were run for this CSS-only visual change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9ae53dcc48323914f48c48c616199)