### PR TITLE
Adjust About hero framing to keep founder image on the right

### DIFF
--- a/style.css
+++ b/style.css
@@ -207,7 +207,7 @@ nav { position: relative; }
   overflow: hidden;
   background-color: #0b0b0b;
   background-image: url('/founderimage.jpeg');
-  background-position: 62% 36%;
+  background-position: 84% 34%;
   background-size: cover;
   background-repeat: no-repeat;
 }
@@ -218,7 +218,7 @@ nav { position: relative; }
   inset: 0;
   background:
     radial-gradient(circle at 32% 28%, rgba(255,255,255,0.32) 0%, rgba(255,255,255,0.08) 30%, rgba(255,255,255,0) 55%),
-    linear-gradient(90deg, rgba(0,0,0,0.56) 0%, rgba(0,0,0,0.30) 48%, rgba(0,0,0,0.14) 100%);
+    linear-gradient(90deg, rgba(0,0,0,0.72) 0%, rgba(0,0,0,0.48) 42%, rgba(0,0,0,0.18) 68%, rgba(0,0,0,0.08) 100%);
   z-index: 1;
 }
 
@@ -373,7 +373,7 @@ footer a:hover { color: var(--brand-dark); text-decoration: underline; }
   .hero-about {
     min-height: 0;
     padding: 100px 6%;
-    background-position: 60% 38%;
+    background-position: 82% 36%;
   }
 }
 
@@ -383,7 +383,7 @@ footer a:hover { color: var(--brand-dark); text-decoration: underline; }
     min-height: 0;
     padding: 100px 6%;
     background-size: cover;
-    background-position: 58% 36%;
+    background-position: 80% 35%;
   }
 }
 
@@ -424,7 +424,7 @@ footer a:hover { color: var(--brand-dark); text-decoration: underline; }
   .hero-about {
     min-height: 0;
     background-size: cover;
-    background-position: 56% 30%;
+    background-position: 72% 28%;
   }
 
   .hero p {


### PR DESCRIPTION
### Motivation
- Align the About hero so the founder portrait sits on the right side and the headline/subtitle remain on the left to prevent the image overlapping the text.
- Improve legibility by increasing the left-to-right overlay strength so copy stands out against the background portrait.

### Description
- Updated `.hero-about` default `background-position` to `84% 34%` to anchor the image further right on large viewports.
- Tuned the `.hero-about::after` overlay `linear-gradient` to stronger left-side darkness for improved contrast.
- Adjusted `background-position` values for laptop, wide-laptop and mobile media queries to `82% 36%`, `80% 35%`, and `72% 28%` respectively.

### Testing
- No automated tests were run for this visual CSS change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9b9a1ab588323955c1d110c9d2e0b)