### PR TITLE
Adjust home hero overlay to make background image more visible

### DIFF
--- a/style.css
+++ b/style.css
@@ -160,7 +160,7 @@ nav { position: relative; }
   background: inherit;
   background-size: cover;
   background-position: center;
-  filter: blur(14px);
+  filter: blur(4px);
   transform: scale(1.12);
   z-index: 0;
 }
@@ -169,7 +169,7 @@ nav { position: relative; }
   content: "";
   position: absolute;
   inset: 0;
-  background: rgba(0,0,0,0.75);
+  background: rgba(0,0,0,0.45);
   z-index: 1;
 }
 


### PR DESCRIPTION
### Motivation
- Improve visibility of the homepage hero background image while preserving readable foreground text and contrast.

### Description
- Reduced blur on ` .hero::before` from `14px` to `4px` and lightened the dark overlay ` .hero::after` from `rgba(0,0,0,0.75)` to `rgba(0,0,0,0.45)` in `style.css`.

### Testing
- No automated tests were run for this static CSS change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9c20fbc8083239eb72d0b2018c99f)