### PR TITLE
Reduce hero overlay darkness and remove background blur

### DIFF
--- a/style.css
+++ b/style.css
@@ -160,7 +160,6 @@ nav { position: relative; }
   background: inherit;
   background-size: cover;
   background-position: center;
-  filter: blur(14px);
   transform: scale(1.12);
   z-index: 0;
 }
@@ -169,7 +168,7 @@ nav { position: relative; }
   content: "";
   position: absolute;
   inset: 0;
-  background: rgba(0,0,0,0.75);
+  background: rgba(0,0,0,0.45);
   z-index: 1;
 }
 


### PR DESCRIPTION
### Motivation
- Improve the index hero visual clarity by removing an aggressive blur and reducing the dark overlay so the background image is more visible.

### Description
- Removed `filter: blur(14px)` from `.hero::before` and changed `.hero::after` background from `rgba(0,0,0,0.75)` to `rgba(0,0,0,0.45)` in `style.css`.

### Testing
- No automated tests were included or run for this stylesheet-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9c20fbc8083239eb72d0b2018c99f)