### PR TITLE
Remove blur layer from home page hero

### DIFF
--- a/style.css
+++ b/style.css
@@ -152,19 +152,6 @@ nav { position: relative; }
   z-index: 2;
 }
 
-/* Index stays darker and more blurry */
-.hero::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: inherit;
-  background-size: cover;
-  background-position: center;
-  filter: blur(4px);
-  transform: scale(1.12);
-  z-index: 0;
-}
-
 .hero::after {
   content: "";
   position: absolute;


### PR DESCRIPTION
### Motivation
- Remove the unwanted blur effect on the home page hero so the background appears sharp while preserving the dark overlay and text legibility.

### Description
- Deleted the `.hero::before` pseudo-element from `style.css`, removing the `filter: blur(4px)` and associated transform while leaving the `.hero::after` overlay and content z-indexing intact.

### Testing
- No automated tests were executed for this CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9c41f3e2c83238c040faa28822f13)