### PR TITLE
Open capability statement PDF in new tab (homepage)

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,8 +59,8 @@
 For partnerships, funding and procurement enquiries
 </p>
 
-<a href="/capability-statement.pdf" class="btn-consultation" download="Project2Pixel-Capability-Statement.pdf" type="application/pdf" aria-label="Download Project2Pixel Capability Statement PDF">
-Download Capability Statement
+<a href="/capability-statement.pdf" class="btn-consultation" target="_blank" rel="noopener" type="application/pdf" aria-label="Open Project2Pixel Capability Statement PDF">
+Open Capability Statement
 </a>
 </div>
 </section>


### PR DESCRIPTION
### Motivation
- Ensure the homepage capability statement CTA opens the PDF in the browser instead of forcing a file download for a better user experience.

### Description
- Updated `index.html` to remove the `download` attribute, add `target="_blank"` and `rel="noopener"`, and change the button text and `aria-label` from "Download" to "Open" so the PDF opens in a new tab.

### Testing
- Verified the PDF is present and served successfully using `python -m http.server` and `curl -I --fail http://127.0.0.1:4173/capability-statement.pdf`, and confirmed the updated markup with `rg` (all checks passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc5b95ee80832394a9a6d3364ec351)