### PR TITLE
Embed Airtable form and clean up contact page markup/styles

### DIFF
--- a/contact/index.html
+++ b/contact/index.html
@@ -61,41 +61,14 @@ Use this form for service enquiries, partnership discussions, programme ideas, f
 </section>
 
 <section class="contact-section">
+<h2>Tell Us About Your Project</h2>
+<p class="section-intro">
+Complete the enquiry form below and we will follow up with the right next step for your business, organisation or partnership idea.
+</p>
 
 <div class="airtable-form-wrapper">
-
-<iframe 
-class="airtable-embed" 
-src="https://airtable.com/embed/appMuL8V3p3Jivtdu/pagRKHiOGOWO1YoxJ/form" 
-frameborder="0" 
-onmousewheel="" 
-width="100%" 
-height="850" 
-style="background: transparent; border: none; border-radius: 16px;">
-</iframe>
-
+<iframe class="airtable-embed" src="https://airtable.com/embed/appMuL8V3p3Jivtdu/pagRKHiOGOWO1YoxJ/form" frameborder="0" onmousewheel="" width="100%" height="533" title="Project2Pixel contact enquiry form"></iframe>
 </div>
-
-<div class="direct-contact">
-<p>📧 Email: <a href="mailto:info@project2pixel.co.za">info@project2pixel.co.za</a></p>
-<p>📍 Centurion, Gauteng, South Africa</p>
-<p>💬 Expect a response within 24 hours.</p>
-</div>
-
-</section>
-
-<label for="email">Your Email:</label>
-<input type="email" id="email" name="_replyto" required>
-
-<label for="message">Your Message:</label>
-<textarea id="message" name="message" placeholder="Tell us about your project..." required></textarea>
-
-<button type="submit" class="btn-consultation">Send Message</button>
-
-<p style="font-size: 0.9rem; margin-top: 10px;">
-By submitting, you agree to our <a href="/terms.html">Terms of Service</a>.
-</p>
-</form>
 
 <div class="direct-contact">
 <p>📧 Email: <a href="mailto:info@project2pixel.co.za">info@project2pixel.co.za</a></p>

--- a/style.css
+++ b/style.css
@@ -610,19 +610,49 @@ select:focus {
   border-color: var(--brand);
 }
 
-.airtable-form-wrapper {
-max-width: 1000px;
-margin: 0 auto;
-padding: 20px;
-background: rgba(255,255,255,0.02);
-border-radius: 20px;
-backdrop-filter: blur(8px);
+.section-intro {
+  max-width: 900px;
+  margin: 0 auto 28px;
+  color: var(--muted);
+  text-align: center;
 }
 
-.airtable-form-wrapper iframe {
-width: 100%;
-min-height: 850px;
-border: none;
-border-radius: 20px;
-overflow: hidden;
+.contact-section h2 {
+  text-align: center;
+}
+
+.airtable-form-wrapper {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 18px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  backdrop-filter: blur(8px);
+  box-shadow: 0 18px 45px rgba(0,0,0,0.22);
+}
+
+.airtable-form-wrapper iframe,
+.airtable-embed {
+  display: block;
+  width: 100%;
+  min-height: 533px;
+  border: 1px solid rgba(255,255,255,0.12);
+  border-radius: 16px;
+  background: transparent;
+  overflow: hidden;
+}
+
+.direct-contact {
+  max-width: 760px;
+  margin: 28px auto 0;
+  padding: 20px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  text-align: center;
+}
+
+.direct-contact p:last-child {
+  margin-bottom: 0;
 }


### PR DESCRIPTION
### Motivation
- Replace the broken native form and duplicate contact blocks with the requested Airtable embed so the contact page shows the live enquiry form.
- Remove leftover/malformed markup and align the contact form visuals with the site’s existing card/glass theme.

### Description
- Replaced stray native form fields and unmatched closing tags in `contact/index.html` with a single accessible Airtable `iframe` using the provided URL and `height="533"`, and added a short intro heading and paragraph.
- Removed duplicate direct-contact block and ensured a single `.direct-contact` card remains below the embed.
- Updated `style.css` to add `.section-intro` and center `.contact-section h2`, and to restyle `.airtable-form-wrapper`, `.airtable-form-wrapper iframe`, `.airtable-embed` and `.direct-contact` so the embed matches the site theme and existing form styling.
- Ensured the iframe has an accessible `title` attribute and consistent sizing for mobile/desktop.

### Testing
- Ran a custom HTML tag check via `python3` which passed for `contact/index.html`.
- Served the site locally with `python3 -m http.server` and verified the contact page returned `200 OK` and contains the Airtable embed via `curl`.
- Verified the old broken form fields and duplicate content are no longer present by inspecting the served HTML with `curl` and searching for keywords.
- Attempted `npx --yes html-validate contact/index.html` but the command failed due to npm registry access returning `403` in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe0e5eec4c8323a7664062ca3a3180)