### PR TITLE
Update initiative nav label and add Centurion, Gauteng to footers

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -27,7 +27,7 @@
 <ul class="nav-links" id="navLinks">
 <li><a href="/">Home</a></li>
 <li><a href="/about/" class="active">About</a></li>
-<li><a href="/initiative/">AI Initiative</a></li>
+<li><a href="/initiative/">Initiative</a></li>
 <li><a href="/services/">Solutions</a></li>
 <li><a href="/speaking/">Speaking</a></li>
 <li><a href="/partnerships/">Partners</a></li>
@@ -118,7 +118,7 @@ Project<span class="highlight-2">2</span>Pixel operates through Project2Pixel (P
 <p>&copy; 2026 Project<span class="highlight-2">2</span>Pixel</p>
 
 <p style="font-size:0.8rem; opacity:0.85;">
-Project2Pixel (PTY) Ltd | Reg: 2025/625844/07 | Level 1 B-BBEE Contributor
+Project2Pixel (PTY) Ltd | Reg: 2025/625844/07 | Centurion, Gauteng | Level 1 B-BBEE Contributor
 </p>
 
 <p>

--- a/cancellation.html
+++ b/cancellation.html
@@ -58,7 +58,7 @@
 <p>&copy; 2026 Project<span class="highlight-2">2</span>Pixel</p>
 
 <p style="font-size:0.8rem; opacity:0.85;">
-Project2Pixel (PTY) Ltd | Reg: 2025/625844/07 | Level 1 B-BBEE Contributor
+Project2Pixel (PTY) Ltd | Reg: 2025/625844/07 | Centurion, Gauteng | Level 1 B-BBEE Contributor
 </p>
 
 <p>

--- a/compliance.html
+++ b/compliance.html
@@ -27,7 +27,7 @@
 <ul class="nav-links" id="navLinks">
 <li><a href="/">Home</a></li>
 <li><a href="/about/">About</a></li>
-<li><a href="/initiative/">AI Initiative</a></li>
+<li><a href="/initiative/">Initiative</a></li>
 <li><a href="/services/">Solutions</a></li>
 <li><a href="/speaking/">Speaking</a></li>
 <li><a href="/partnerships/">Partners</a></li>
@@ -73,7 +73,7 @@ Our Capability Statement provides a structured overview of our services, deliver
 <p>&copy; 2026 Project<span class="highlight-2">2</span>Pixel</p>
 
 <p style="font-size:0.8rem; opacity:0.85;">
-Project2Pixel (PTY) Ltd | Reg: 2025/625844/07 | Level 1 B-BBEE Contributor
+Project2Pixel (PTY) Ltd | Reg: 2025/625844/07 | Centurion, Gauteng | Level 1 B-BBEE Contributor
 </p>
 
 <p>

--- a/contact/index.html
+++ b/contact/index.html
@@ -23,7 +23,7 @@
 <ul class="nav-links" id="navLinks">
 <li><a href="/">Home</a></li>
 <li><a href="/about/">About</a></li>
-<li><a href="/initiative/">AI Initiative</a></li>
+<li><a href="/initiative/">Initiative</a></li>
 <li><a href="/services/">Solutions</a></li>
 <li><a href="/speaking/">Speaking</a></li>
 <li><a href="/partnerships/">Partners</a></li>
@@ -102,7 +102,7 @@ Complete the enquiry form below and we will follow up with the right next step f
 <p>&copy; 2026 Project<span class="highlight-2">2</span>Pixel</p>
 
 <p style="font-size:0.8rem; opacity:0.85;">
-Project2Pixel (PTY) Ltd | Reg: 2025/625844/07 | Level 1 B-BBEE Contributor
+Project2Pixel (PTY) Ltd | Reg: 2025/625844/07 | Centurion, Gauteng | Level 1 B-BBEE Contributor
 </p>
 
 <p>

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
     <ul class="nav-links" id="navLinks">
       <li><a href="/" class="active">Home</a></li>
       <li><a href="/about/">About</a></li>
-      <li><a href="/initiative/">AI Initiative</a></li>
+      <li><a href="/initiative/">Initiative</a></li>
       <li><a href="/services/">Solutions</a></li>
       <li><a href="/speaking/">Speaking</a></li>
       <li><a href="/partnerships/">Partners</a></li>
@@ -308,7 +308,7 @@
 <p>&copy; 2026 Project<span class="highlight-2">2</span>Pixel</p>
 
 <p style="font-size:0.8rem; opacity:0.85;">
-Project2Pixel (PTY) Ltd | Reg: 2025/625844/07 | Level 1 B-BBEE Contributor
+Project2Pixel (PTY) Ltd | Reg: 2025/625844/07 | Centurion, Gauteng | Level 1 B-BBEE Contributor
 </p>
 
 <p>

--- a/initiative/index.html
+++ b/initiative/index.html
@@ -27,7 +27,7 @@
 <ul class="nav-links" id="navLinks">
 <li><a href="/">Home</a></li>
 <li><a href="/about/">About</a></li>
-<li><a href="/initiative/" class="active">AI Initiative</a></li>
+<li><a href="/initiative/" class="active">Initiative</a></li>
 <li><a href="/services/">Solutions</a></li>
 <li><a href="/speaking/">Speaking</a></li>
 <li><a href="/partnerships/">Partners</a></li>
@@ -271,7 +271,7 @@ The Project<span class="brand-2">2</span>Pixel AI & Digital Enablement Initiativ
 <p>&copy; 2026 Project<span class="highlight-2">2</span>Pixel</p>
 
 <p style="font-size:0.8rem; opacity:0.85;">
-Project2Pixel (PTY) Ltd | Reg: 2025/625844/07 | Level 1 B-BBEE Contributor
+Project2Pixel (PTY) Ltd | Reg: 2025/625844/07 | Centurion, Gauteng | Level 1 B-BBEE Contributor
 </p>
 
 <p>

--- a/partnerships/index.html
+++ b/partnerships/index.html
@@ -29,7 +29,7 @@
     <ul class="nav-links" id="navLinks">
       <li><a href="/">Home</a></li>
       <li><a href="/about/">About</a></li>
-      <li><a href="/initiative/">AI Initiative</a></li>
+      <li><a href="/initiative/">Initiative</a></li>
       <li><a href="/services/">Solutions</a></li>
       <li><a href="/speaking/">Speaking</a></li>
       <li><a href="/partnerships/" class="active">Partners</a></li>
@@ -351,7 +351,7 @@ We welcome conversations with funders, NGOs, government departments and partners
 <p>&copy; 2026 Project<span class="highlight-2">2</span>Pixel</p>
 
 <p style="font-size:0.8rem; opacity:0.85;">
-Project2Pixel (PTY) Ltd | Reg: 2025/625844/07 | Level 1 B-BBEE Contributor
+Project2Pixel (PTY) Ltd | Reg: 2025/625844/07 | Centurion, Gauteng | Level 1 B-BBEE Contributor
 </p>
 
 <p>

--- a/privacy.html
+++ b/privacy.html
@@ -57,7 +57,7 @@
 <p>&copy; 2026 Project<span class="highlight-2">2</span>Pixel</p>
 
 <p style="font-size:0.8rem; opacity:0.85;">
-Project2Pixel (PTY) Ltd | Reg: 2025/625844/07 | Level 1 B-BBEE Contributor
+Project2Pixel (PTY) Ltd | Reg: 2025/625844/07 | Centurion, Gauteng | Level 1 B-BBEE Contributor
 </p>
 
 <p>

--- a/services/index.html
+++ b/services/index.html
@@ -33,7 +33,7 @@
       <ul class="nav-links" id="navLinks">
       <li><a href="/">Home</a></li>
       <li><a href="/about/">About</a></li>
-      <li><a href="/initiative/">AI Initiative</a></li>
+      <li><a href="/initiative/">Initiative</a></li>
       <li><a href="/services/" class="active">Solutions</a></li>
       <li><a href="/speaking/">Speaking</a></li>
       <li><a href="/partnerships/">Partners</a></li>
@@ -318,7 +318,7 @@
     <p>&copy; 2026 Project<span class="highlight-2">2</span>Pixel</p>
 
     <p style="font-size:0.8rem; opacity:0.85;">
-      Project2Pixel (PTY) Ltd | Reg: 2025/625844/07 | Level 1 B-BBEE Contributor
+      Project2Pixel (PTY) Ltd | Reg: 2025/625844/07 | Centurion, Gauteng | Level 1 B-BBEE Contributor
     </p>
 
     <p>

--- a/speaking/index.html
+++ b/speaking/index.html
@@ -27,7 +27,7 @@
 <ul class="nav-links" id="navLinks">
 <li><a href="/">Home</a></li>
 <li><a href="/about/">About</a></li>
-<li><a href="/initiative/">AI Initiative</a></li>
+<li><a href="/initiative/">Initiative</a></li>
 <li><a href="/services/">Solutions</a></li>
 <li><a href="/speaking/" class="active">Speaking</a></li>
 <li><a href="/partnerships/">Partners</a></li>
@@ -147,7 +147,7 @@ Natasha speaks at the intersection of AI transformation, governance alignment an
 <p>&copy; 2026 Project<span class="highlight-2">2</span>Pixel</p>
 
 <p style="font-size:0.8rem; opacity:0.85;">
-Project2Pixel (PTY) Ltd | Reg: 2025/625844/07 | Level 1 B-BBEE Contributor
+Project2Pixel (PTY) Ltd | Reg: 2025/625844/07 | Centurion, Gauteng | Level 1 B-BBEE Contributor
 </p>
 
 <p>

--- a/terms.html
+++ b/terms.html
@@ -68,7 +68,7 @@
 <p>&copy; 2026 Project<span class="highlight-2">2</span>Pixel</p>
 
 <p style="font-size:0.8rem; opacity:0.85;">
-Project2Pixel (PTY) Ltd | Reg: 2025/625844/07 | Level 1 B-BBEE Contributor
+Project2Pixel (PTY) Ltd | Reg: 2025/625844/07 | Centurion, Gauteng | Level 1 B-BBEE Contributor
 </p>
 
 <p>

--- a/thank-you.html
+++ b/thank-you.html
@@ -298,6 +298,10 @@
         🌐 www.project2pixel.co.za
       </p>
 
+      <p>
+        📍 Centurion, Gauteng
+      </p>
+
     </div>
 
   </div>


### PR DESCRIPTION
### Motivation
- Align the site navigation with the updated Initiative page naming by changing the nav label from `AI Initiative` to `Initiative` across the site.
- Include the business location in site footers for clearer contact/legal information by adding `Centurion, Gauteng` to the standard footer block and the thank-you contact block.

### Description
- Replaced the navigation label `AI Initiative` with `Initiative` in site navigation across HTML pages including `index.html`, `about/index.html`, `services/index.html`, `initiative/index.html`, `partnerships/index.html`, `speaking/index.html`, `contact/index.html`, and `compliance.html`.
- Inserted `Centurion, Gauteng` into the standard footer business details in `index.html`, `about/index.html`, `services/index.html`, `initiative/index.html`, `partnerships/index.html`, `speaking/index.html`, `contact/index.html`, `compliance.html`, `privacy.html`, `terms.html`, and `cancellation.html` and added the location line to the thank-you contact block in `thank-you.html`.
- No other content or layout changes were made and the Initiative page title (`AI & Digital Enablement Initiative`) was left as-is.

### Testing
- Ran a script that scanned and updated `*.html` files to ensure no instances of `AI Initiative` remain and that every `<footer>` contains `Centurion, Gauteng`, and the check passed.
- Served the site with `python -m http.server` and fetched the homepage using `urllib` to assert `>Initiative</a>` and `Centurion, Gauteng` are present in the rendered HTML, and the assertions passed.
- Ran `git diff --check` to ensure no whitespace or diff issues were introduced and it passed; an automated check for a local browser binary (`which chromium || which chromium-browser || which google-chrome || which firefox`) found no browser available so automated screenshot capture was not possible.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0181036ce0832383ece3f664bb452f)