### PR TITLE
Add Solution Packages section to Services page

### DIFF
--- a/services/index.html
+++ b/services/index.html
@@ -125,6 +125,102 @@
 
   </section>
 
+  <!-- SOLUTION PACKAGES -->
+
+  <section>
+
+    <h2 style="text-align:center; margin-bottom:20px;">
+      Solution Packages
+    </h2>
+
+    <p style="max-width:900px; margin:0 auto 40px auto; text-align:center;">
+      Clear starting points for businesses, NGOs and organisations that need practical digital systems, operational structure and scalable workflow support.
+    </p>
+
+    <div class="features">
+
+      <div class="service-card">
+
+        <h3>Digital Foundation Setup</h3>
+
+        <p style="font-weight:700; color:#1DD1A1; margin-bottom:15px;">
+          From R3,950 once-off
+        </p>
+
+        <p>
+          For startups, NGOs and small teams that need a professional digital presence and basic operational structure.
+        </p>
+
+        <ul style="text-align:left; padding-left:20px;">
+          <li>One-page website or landing page</li>
+          <li>Contact or enquiry form setup</li>
+          <li>Basic booking integration</li>
+          <li>Admin workflow recommendations</li>
+          <li>Mobile responsive setup</li>
+        </ul>
+
+        <a href="/contact/" class="btn-consultation">
+          Start Setup
+        </a>
+
+      </div>
+
+      <div class="service-card">
+
+        <h3>Operational Growth Support</h3>
+
+        <p style="font-weight:700; color:#1DD1A1; margin-bottom:15px;">
+          From R999/month
+        </p>
+
+        <p>
+          For organisations that need ongoing website updates, workflow improvements, CRM support and operational assistance.
+        </p>
+
+        <ul style="text-align:left; padding-left:20px;">
+          <li>Website maintenance</li>
+          <li>CRM and lead tracking support</li>
+          <li>Workflow optimisation</li>
+          <li>Monthly operational support</li>
+          <li>Digital system updates</li>
+        </ul>
+
+        <a href="/contact/" class="btn-consultation">
+          Grow My Systems
+        </a>
+
+      </div>
+
+      <div class="service-card">
+
+        <h3>Automation & Scale Systems</h3>
+
+        <p style="font-weight:700; color:#1DD1A1; margin-bottom:15px;">
+          Custom Pricing
+        </p>
+
+        <p>
+          For organisations ready to implement advanced CRM systems, AI workflows, automation and digital enablement support.
+        </p>
+
+        <ul style="text-align:left; padding-left:20px;">
+          <li>Workflow automation setup</li>
+          <li>CRM and pipeline systems</li>
+          <li>AI productivity integration</li>
+          <li>Operational dashboards</li>
+          <li>Training and onboarding support</li>
+        </ul>
+
+        <a href="/contact/" class="btn-consultation">
+          Scale My Operations
+        </a>
+
+      </div>
+
+    </div>
+
+  </section>
+
   <!-- TRAINING & CAPACITY BUILDING -->
 
   <section>


### PR DESCRIPTION
### Motivation

- Provide clear, opinionated starter packages to help visitors choose packaged service offerings alongside the existing Core Services and Training pages. 
- Surface concise pricing and CTAs to improve conversion paths for startups, NGOs and small teams looking for immediate engagement.

### Description

- Inserted a new `Solution Packages` HTML section into `services/index.html` between the existing Core Services and Training & Capacity Building sections. 
- Added three package cards: `Digital Foundation Setup`, `Operational Growth Support`, and `Automation & Scale Systems`, each with pricing, short descriptions, feature lists and contact CTAs. 
- Kept markup consistent with the existing page structure and CSS classes (`service-card`, `features`, `btn-consultation`) to reuse existing styles.

### Testing

- Ran `git diff --check` to validate whitespace and diff issues and it completed without errors. 
- Parsed the modified page with a small `python3` script using `html.parser.HTMLParser` to ensure the document is well-formed and the parser completed successfully. 
- Checked for available browser/playwright tooling and system browser binaries; those were not present in the environment so no visual screenshot test was performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01833d9d2483239ca3fc13d87619bb)