### PR TITLE
Move Certified Technology Partners section out of partnerships hero

### DIFF
--- a/partnerships/index.html
+++ b/partnerships/index.html
@@ -48,19 +48,20 @@ Project<span class="highlight-2">2</span>Pixel partners with funders, NGOs, gove
 Level 1 B-BBEE Contributor | 100% Black Female-Owned | South African Registered Private Company
 </p>
 
-<section>
-  <h2>Certified Technology Partners & Facilitators</h2>
+</section>
 
-  <p>
+<section style="text-align:center;">
+  <h2>Certified Technology Partners &amp; Facilitators</h2>
+
+  <p style="max-width:900px; margin:0 auto 18px;">
     Project 2 Pixel works through a collaborative delivery model, partnering with certified technology professionals, facilitators, trainers and implementation specialists where required.
   </p>
 
-  <p>
+  <p style="max-width:900px; margin:0 auto 30px;">
     This allows us to support larger digital transformation, AI literacy, workflow automation, training and capacity-building projects while keeping delivery practical, scalable and aligned to each organisation’s needs.
   </p>
-</section>
 
-<a href="/contact/" class="btn-consultation">Start a Partnership Conversation</a>
+  <a href="/contact/" class="btn-consultation">Start a Partnership Conversation</a>
 </section>
 
 <section>


### PR DESCRIPTION
### Motivation
- Improve the partnerships page layout by moving the “Certified Technology Partners & Facilitators” content out of the hero area so the hero finishes with company credentials and a cleaner visual hierarchy. 
- Make the certified partners content stand alone and clearly visible with the CTA preserved for partnership enquiries.

### Description
- Removed the certified partners block from inside the `.hero-services` section and added it as a new `<section style="text-align:center;">` immediately after the hero. 
- Added inline `max-width`/`margin` styles to the two partner paragraphs and escaped the ampersand in the heading (`&amp;`) to match HTML semantics. 
- Kept the `Start a Partnership Conversation` CTA inside the new centered section and fixed surrounding closing tags to maintain valid HTML structure.

### Testing
- Ran `git diff --check` which reported no issues. 
- Parsed `partnerships/index.html` with Python's `HTMLParser` which completed without errors. 
- Attempted a visual test with `npx --yes playwright screenshot ...` but the run failed due to `npm` registry `403 Forbidden` in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01cb04cc488323a3a7ec570740d410)