### PR TITLE
Normalize Project2Pixel branding and use shared aqua color

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -109,7 +109,7 @@ Project<span class="brand-2">2</span>Pixel is being built to serve both commerci
 <h2>Registered Business</h2>
 
 <p style="max-width:900px; margin:0 auto;">
-Project<span class="highlight-2">2</span>Pixel operates through Project2Pixel (PTY) LTD, a South African registered private company providing digital transformation, workflow systems, AI enablement and operational support services.
+Project<span class="highlight-2">2</span>Pixel operates through Project<span class="brand-2">2</span>Pixel (PTY) LTD, a South African registered private company providing digital transformation, workflow systems, AI enablement and operational support services.
 </p>
 </section>
 
@@ -117,7 +117,7 @@ Project<span class="highlight-2">2</span>Pixel operates through Project2Pixel (P
 <p>&copy; 2026 Project<span class="highlight-2">2</span>Pixel</p>
 
 <p style="font-size:0.8rem; opacity:0.85;">
-Project2Pixel (PTY) Ltd | Reg: 2025/625844/07 | Centurion, Gauteng | Level 1 B-BBEE Contributor
+Project<span class="brand-2">2</span>Pixel (PTY) Ltd | Reg: 2025/625844/07 | Centurion, Gauteng | Level 1 B-BBEE Contributor
 </p>
 
 <p>

--- a/cancellation.html
+++ b/cancellation.html
@@ -58,7 +58,7 @@
 <p>&copy; 2026 Project<span class="highlight-2">2</span>Pixel</p>
 
 <p style="font-size:0.8rem; opacity:0.85;">
-Project2Pixel (PTY) Ltd | Reg: 2025/625844/07 | Centurion, Gauteng | Level 1 B-BBEE Contributor
+Project<span class="brand-2">2</span>Pixel (PTY) Ltd | Reg: 2025/625844/07 | Centurion, Gauteng | Level 1 B-BBEE Contributor
 </p>
 
 <p>

--- a/compliance.html
+++ b/compliance.html
@@ -46,7 +46,7 @@ Basic company and procurement information for Project<span class="highlight-2">2
 <h2>Company Information</h2>
 
 <div style="max-width:750px; margin:25px auto; text-align:left;">
-<p><strong>Registered Name:</strong> Project2Pixel (PTY) Ltd</p>
+<p><strong>Registered Name:</strong> Project<span class="brand-2">2</span>Pixel (PTY) Ltd</p>
 <p><strong>Registration Number:</strong> 2025/625844/07</p>
 <p><strong>Enterprise Type:</strong> Private Company</p>
 <p><strong>Enterprise Status:</strong> In Business</p>
@@ -72,7 +72,7 @@ Our Capability Statement provides a structured overview of our services, deliver
 <p>&copy; 2026 Project<span class="highlight-2">2</span>Pixel</p>
 
 <p style="font-size:0.8rem; opacity:0.85;">
-Project2Pixel (PTY) Ltd | Reg: 2025/625844/07 | Centurion, Gauteng | Level 1 B-BBEE Contributor
+Project<span class="brand-2">2</span>Pixel (PTY) Ltd | Reg: 2025/625844/07 | Centurion, Gauteng | Level 1 B-BBEE Contributor
 </p>
 
 <p>

--- a/contact/index.html
+++ b/contact/index.html
@@ -101,7 +101,7 @@ Complete the enquiry form below and we will follow up with the right next step f
 <p>&copy; 2026 Project<span class="highlight-2">2</span>Pixel</p>
 
 <p style="font-size:0.8rem; opacity:0.85;">
-Project2Pixel (PTY) Ltd | Reg: 2025/625844/07 | Centurion, Gauteng | Level 1 B-BBEE Contributor
+Project<span class="brand-2">2</span>Pixel (PTY) Ltd | Reg: 2025/625844/07 | Centurion, Gauteng | Level 1 B-BBEE Contributor
 </p>
 
 <p>

--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
   <h2>Collaborative Delivery Model</h2>
 
   <p>
-    Project 2 Pixel collaborates with certified technology professionals, facilitators and implementation partners where required to support scalable AI, automation, CRM, training and digital capacity-building projects.
+    Project<span class="brand-2">2</span>Pixel collaborates with certified technology professionals, facilitators and implementation partners where required to support scalable AI, automation, CRM, training and digital capacity-building projects.
   </p>
 </section>
 
@@ -315,7 +315,7 @@
 <p>&copy; 2026 Project<span class="highlight-2">2</span>Pixel</p>
 
 <p style="font-size:0.8rem; opacity:0.85;">
-Project2Pixel (PTY) Ltd | Reg: 2025/625844/07 | Centurion, Gauteng | Level 1 B-BBEE Contributor
+Project<span class="brand-2">2</span>Pixel (PTY) Ltd | Reg: 2025/625844/07 | Centurion, Gauteng | Level 1 B-BBEE Contributor
 </p>
 
 <p>

--- a/initiative/index.html
+++ b/initiative/index.html
@@ -270,7 +270,7 @@ The Project<span class="brand-2">2</span>Pixel AI & Digital Enablement Initiativ
 <p>&copy; 2026 Project<span class="highlight-2">2</span>Pixel</p>
 
 <p style="font-size:0.8rem; opacity:0.85;">
-Project2Pixel (PTY) Ltd | Reg: 2025/625844/07 | Centurion, Gauteng | Level 1 B-BBEE Contributor
+Project<span class="brand-2">2</span>Pixel (PTY) Ltd | Reg: 2025/625844/07 | Centurion, Gauteng | Level 1 B-BBEE Contributor
 </p>
 
 <p>

--- a/partnerships/index.html
+++ b/partnerships/index.html
@@ -54,7 +54,7 @@ Level 1 B-BBEE Contributor | 100% Black Female-Owned | South African Registered 
   <h2>Certified Technology Partners &amp; Facilitators</h2>
 
   <p style="max-width:900px; margin:0 auto 18px;">
-    Project 2 Pixel works through a collaborative delivery model, partnering with certified technology professionals, facilitators, trainers and implementation specialists where required.
+    Project<span class="brand-2">2</span>Pixel works through a collaborative delivery model, partnering with certified technology professionals, facilitators, trainers and implementation specialists where required.
   </p>
 
   <p style="max-width:900px; margin:0 auto 30px;">
@@ -293,11 +293,11 @@ These examples represent structured implementation models and potential delivery
 <h2>Company & Procurement Details</h2>
 
 <p style="max-width:900px; margin:0 auto;">
-Project<span class="highlight-2">2</span>Pixel operates through Project2Pixel (PTY) Ltd, a South African registered private company available for partnership, procurement and programme implementation opportunities.
+Project<span class="highlight-2">2</span>Pixel operates through Project<span class="brand-2">2</span>Pixel (PTY) Ltd, a South African registered private company available for partnership, procurement and programme implementation opportunities.
 </p>
 
 <div style="max-width:700px; margin:25px auto; text-align:left;">
-<p><strong>Registered Name:</strong> Project2Pixel (PTY) Ltd</p>
+<p><strong>Registered Name:</strong> Project<span class="brand-2">2</span>Pixel (PTY) Ltd</p>
 <p><strong>Registration Number:</strong> 2025/625844/07</p>
 <p><strong>B-BBEE Status:</strong> Level 1 Contributor</p>
 <p><strong>Procurement Recognition:</strong> 135%</p>
@@ -363,7 +363,7 @@ We welcome conversations with funders, NGOs, government departments and partners
 <p>&copy; 2026 Project<span class="highlight-2">2</span>Pixel</p>
 
 <p style="font-size:0.8rem; opacity:0.85;">
-Project2Pixel (PTY) Ltd | Reg: 2025/625844/07 | Centurion, Gauteng | Level 1 B-BBEE Contributor
+Project<span class="brand-2">2</span>Pixel (PTY) Ltd | Reg: 2025/625844/07 | Centurion, Gauteng | Level 1 B-BBEE Contributor
 </p>
 
 <p>

--- a/privacy.html
+++ b/privacy.html
@@ -15,7 +15,7 @@
 
 <section>
 <h2>1. Introduction</h2>
-<p>Project2Pixel ("we", "us", or "our") is committed to protecting your personal information in accordance with the Protection of Personal Information Act (POPIA) of South Africa.</p>
+<p>Project<span class="brand-2">2</span>Pixel ("we", "us", or "our") is committed to protecting your personal information in accordance with the Protection of Personal Information Act (POPIA) of South Africa.</p>
 
 <h2>2. Information We Collect</h2>
 <p>We may collect the following information when you interact with our website:</p>
@@ -57,7 +57,7 @@
 <p>&copy; 2026 Project<span class="highlight-2">2</span>Pixel</p>
 
 <p style="font-size:0.8rem; opacity:0.85;">
-Project2Pixel (PTY) Ltd | Reg: 2025/625844/07 | Centurion, Gauteng | Level 1 B-BBEE Contributor
+Project<span class="brand-2">2</span>Pixel (PTY) Ltd | Reg: 2025/625844/07 | Centurion, Gauteng | Level 1 B-BBEE Contributor
 </p>
 
 <p>

--- a/script.js
+++ b/script.js
@@ -34,7 +34,7 @@ const highlightProject2Pixel = () => {
 
   while (walker.nextNode()) {
     const node = walker.currentNode
-    if (!node.nodeValue.includes("Project2Pixel")) continue
+    if (!/Project\s*2\s*Pixel/.test(node.nodeValue)) continue
 
     const parent = node.parentElement
     if (!parent) continue
@@ -46,7 +46,7 @@ const highlightProject2Pixel = () => {
 
   textNodes.forEach((node) => {
     const wrapper = document.createElement("span")
-    wrapper.innerHTML = node.nodeValue.replaceAll("Project2Pixel", 'Project<span class="brand-2">2</span>Pixel')
+    wrapper.innerHTML = node.nodeValue.replace(/Project\s*2\s*Pixel/g, 'Project<span class="brand-2">2</span>Pixel')
     node.parentNode.replaceChild(wrapper, node)
   })
 }

--- a/services/index.html
+++ b/services/index.html
@@ -126,7 +126,7 @@
 
         <h3>Digital Foundation Setup</h3>
 
-        <p style="font-weight:700; color:#1DD1A1; margin-bottom:15px;">
+        <p style="font-weight:700; color:var(--brand); margin-bottom:15px;">
           From R3,950 once-off
         </p>
 
@@ -152,7 +152,7 @@
 
         <h3>Operational Growth Support</h3>
 
-        <p style="font-weight:700; color:#1DD1A1; margin-bottom:15px;">
+        <p style="font-weight:700; color:var(--brand); margin-bottom:15px;">
           From R999/month
         </p>
 
@@ -178,7 +178,7 @@
 
         <h3>Automation & Scale Systems</h3>
 
-        <p style="font-weight:700; color:#1DD1A1; margin-bottom:15px;">
+        <p style="font-weight:700; color:var(--brand); margin-bottom:15px;">
           Custom Pricing
         </p>
 
@@ -223,7 +223,7 @@
       <h2>Certified Technology Partners & Facilitators</h2>
 
       <p>
-        Project 2 Pixel works through a collaborative delivery model, partnering with certified technology professionals, facilitators, trainers and implementation specialists where required.
+        Project<span class="brand-2">2</span>Pixel works through a collaborative delivery model, partnering with certified technology professionals, facilitators, trainers and implementation specialists where required.
       </p>
 
       <p>
@@ -409,7 +409,7 @@
     <p>&copy; 2026 Project<span class="highlight-2">2</span>Pixel</p>
 
     <p style="font-size:0.8rem; opacity:0.85;">
-      Project2Pixel (PTY) Ltd | Reg: 2025/625844/07 | Centurion, Gauteng | Level 1 B-BBEE Contributor
+      Project<span class="brand-2">2</span>Pixel (PTY) Ltd | Reg: 2025/625844/07 | Centurion, Gauteng | Level 1 B-BBEE Contributor
     </p>
 
     <p>

--- a/terms.html
+++ b/terms.html
@@ -16,10 +16,10 @@
 <section>
 
 <h2>1. Introduction</h2>
-<p>These Terms of Service govern the use of services provided by Project2Pixel. By engaging our services, you agree to these terms.</p>
+<p>These Terms of Service govern the use of services provided by Project<span class="brand-2">2</span>Pixel. By engaging our services, you agree to these terms.</p>
 
 <h2>2. Services Offered</h2>
-<p>Project2Pixel provides digital solutions including but not limited to:</p>
+<p>Project<span class="brand-2">2</span>Pixel provides digital solutions including but not limited to:</p>
 <ul>
 <li>Workflow and administrative systems</li>
 <li>Website and digital infrastructure development</li>
@@ -51,10 +51,10 @@
 <p>Project timelines depend on client responsiveness. Delays in communication may affect delivery timelines.</p>
 
 <h2>8. Intellectual Property</h2>
-<p>All final deliverables become the client's property upon full payment. Project2Pixel reserves the right to showcase work in its portfolio.</p>
+<p>All final deliverables become the client's property upon full payment. Project<span class="brand-2">2</span>Pixel reserves the right to showcase work in its portfolio.</p>
 
 <h2>9. Limitation of Liability</h2>
-<p>Project2Pixel is not liable for any indirect or consequential damages arising from the use of our services.</p>
+<p>Project<span class="brand-2">2</span>Pixel is not liable for any indirect or consequential damages arising from the use of our services.</p>
 
 <h2>10. Termination</h2>
 <p>Either party may terminate a project. Work completed up to that point will be billed accordingly.</p>
@@ -68,7 +68,7 @@
 <p>&copy; 2026 Project<span class="highlight-2">2</span>Pixel</p>
 
 <p style="font-size:0.8rem; opacity:0.85;">
-Project2Pixel (PTY) Ltd | Reg: 2025/625844/07 | Centurion, Gauteng | Level 1 B-BBEE Contributor
+Project<span class="brand-2">2</span>Pixel (PTY) Ltd | Reg: 2025/625844/07 | Centurion, Gauteng | Level 1 B-BBEE Contributor
 </p>
 
 <p>

--- a/thank-you.html
+++ b/thank-you.html
@@ -197,7 +197,7 @@
     <!-- HEADER -->
     <div class="header">
 
-      <img 
+      <img
         src="/project2pixel-logo-480.png"
         alt="Project2Pixel"
       >
@@ -216,7 +216,7 @@
       </h1>
 
       <p class="intro">
-        Thank you for scheduling your Project2Pixel Discovery Call, 
+        Thank you for scheduling your Project<span class="brand-2">2</span>Pixel Discovery Call,
         <strong id="clientName">there</strong>.
       </p>
 
@@ -260,7 +260,7 @@
 
         <ul>
           <li>✔ A Google Meet invitation has been sent to your email.</li>
-          <li>✔ Your booking has been added to the Project2Pixel workflow system.</li>
+          <li>✔ Your booking has been added to the Project<span class="brand-2">2</span>Pixel workflow system.</li>
           <li>✔ We’ll review your project information before the discovery session.</li>
         </ul>
 
@@ -276,7 +276,7 @@
 
         <a href="https://project2pixel.co.za/contact/"
            class="btn secondary-btn">
-           Contact Project2Pixel
+           Contact Project<span class="brand-2">2</span>Pixel
         </a>
 
       </div>


### PR DESCRIPTION
### Motivation
- Ensure the company name displays consistently as `Project2Pixel` with the `2` rendered in the shared aqua brand color across the partnership page and all site pages. 
- Replace hard-coded aqua values with the central CSS variable to keep brand colour consistent and maintainable. 
- Make the client-side highlight script robust to both spaced and unspaced variants so runtime text is normalized. 
- Avoid injecting markup into attributes by updating only visible content while keeping `alt`/`meta`/`title` attributes safe and readable.

### Description
- Replaced visible occurrences of the spaced and unspaced brand name with `Project<span class="brand-2">2</span>Pixel` across multiple HTML pages including `index.html`, `partnerships/index.html`, `services/index.html`, `privacy.html`, `terms.html`, `about/index.html`, `contact/index.html`, `initiative/index.html`, `compliance.html`, `cancellation.html`, and `thank-you.html`. 
- Replaced inline hard-coded aqua color `#1DD1A1` in `services/index.html` with `color:var(--brand)` and confirmed `.highlight-2` and `.brand-2` use the `--brand` value in `style.css`. 
- Updated `script.js` to use a regex (`/Project\s*2\s*Pixel/`) to detect both `Project2Pixel` and `Project 2 Pixel` and replace visible text with the styled markup via `replace(/Project\s*2\s*Pixel/g, 'Project<span class="brand-2">2</span>Pixel')`. 
- Kept machine-readable attributes plain (no injected HTML) and adjusted visible footer/legal/company lines to the new styled markup to ensure consistent on-page rendering.

### Testing
- Ran `node --check script.js` to validate JavaScript syntax and it succeeded. 
- Used ripgrep checks for patterns such as `Project\s+2\s+Pixel` and `#1DD1A1` to confirm replacements and the searches returned no remaining mismatches. 
- Ran `git diff --check` to validate whitespace and basic diff issues and it reported no remaining problems. 
- Attempted `npx --yes playwright --version` to capture visual regression screenshots but the npm registry request was blocked with HTTP 403 in this environment, so automated visual testing could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01ccf394348323ba64131ce1e501dd)